### PR TITLE
Added support for Maya 2017

### DIFF
--- a/anim_picker/Qt.py
+++ b/anim_picker/Qt.py
@@ -1,0 +1,1554 @@
+"""Minimal Python 2 & 3 shim around all Qt bindings
+
+DOCUMENTATION
+    Qt.py was born in the film and visual effects industry to address
+    the growing need for the development of software capable of running
+    with more than one flavour of the Qt bindings for Python - PySide,
+    PySide2, PyQt4 and PyQt5.
+
+    1. Build for one, run with all
+    2. Explicit is better than implicit
+    3. Support co-existence
+
+    Default resolution order:
+        - PySide2
+        - PyQt5
+        - PySide
+        - PyQt4
+
+    Usage:
+        >> import sys
+        >> from Qt import QtWidgets
+        >> app = QtWidgets.QApplication(sys.argv)
+        >> button = QtWidgets.QPushButton("Hello World")
+        >> button.show()
+        >> app.exec_()
+
+    All members of PySide2 are mapped from other bindings, should they exist.
+    If no equivalent member exist, it is excluded from Qt.py and inaccessible.
+    The idea is to highlight members that exist across all supported binding,
+    and guarantee that code that runs on one binding runs on all others.
+
+    For more details, visit https://github.com/mottosso/Qt.py
+
+LICENSE
+
+    See end of file for license (MIT, BSD) information.
+
+"""
+
+import os
+import sys
+import types
+import shutil
+import importlib
+
+
+__version__ = "1.1.0.b3"
+
+# Enable support for `from Qt import *`
+__all__ = []
+
+# Flags from environment variables
+QT_VERBOSE = bool(os.getenv("QT_VERBOSE"))
+QT_PREFERRED_BINDING = os.getenv("QT_PREFERRED_BINDING", "")
+QT_SIP_API_HINT = os.getenv("QT_SIP_API_HINT")
+
+# Reference to Qt.py
+Qt = sys.modules[__name__]
+Qt.QtCompat = types.ModuleType("QtCompat")
+
+try:
+    long
+except NameError:
+    # Python 3 compatibility
+    long = int
+
+"""Common members of all bindings
+
+This is where each member of Qt.py is explicitly defined.
+It is based on a "lowest common denominator" of all bindings;
+including members found in each of the 4 bindings.
+
+Find or add excluded members in build_membership.py
+
+"""
+
+_common_members = {
+    "QtGui": [
+        "QAbstractTextDocumentLayout",
+        "QActionEvent",
+        "QBitmap",
+        "QBrush",
+        "QClipboard",
+        "QCloseEvent",
+        "QColor",
+        "QConicalGradient",
+        "QContextMenuEvent",
+        "QCursor",
+        "QDoubleValidator",
+        "QDrag",
+        "QDragEnterEvent",
+        "QDragLeaveEvent",
+        "QDragMoveEvent",
+        "QDropEvent",
+        "QFileOpenEvent",
+        "QFocusEvent",
+        "QFont",
+        "QFontDatabase",
+        "QFontInfo",
+        "QFontMetrics",
+        "QFontMetricsF",
+        "QGradient",
+        "QHelpEvent",
+        "QHideEvent",
+        "QHoverEvent",
+        "QIcon",
+        "QIconDragEvent",
+        "QIconEngine",
+        "QImage",
+        "QImageIOHandler",
+        "QImageReader",
+        "QImageWriter",
+        "QInputEvent",
+        "QInputMethodEvent",
+        "QIntValidator",
+        "QKeyEvent",
+        "QKeySequence",
+        "QLinearGradient",
+        "QMatrix2x2",
+        "QMatrix2x3",
+        "QMatrix2x4",
+        "QMatrix3x2",
+        "QMatrix3x3",
+        "QMatrix3x4",
+        "QMatrix4x2",
+        "QMatrix4x3",
+        "QMatrix4x4",
+        "QMouseEvent",
+        "QMoveEvent",
+        "QMovie",
+        "QPaintDevice",
+        "QPaintEngine",
+        "QPaintEngineState",
+        "QPaintEvent",
+        "QPainter",
+        "QPainterPath",
+        "QPainterPathStroker",
+        "QPalette",
+        "QPen",
+        "QPicture",
+        "QPictureIO",
+        "QPixmap",
+        "QPixmapCache",
+        "QPolygon",
+        "QPolygonF",
+        "QQuaternion",
+        "QRadialGradient",
+        "QRegExpValidator",
+        "QRegion",
+        "QResizeEvent",
+        "QSessionManager",
+        "QShortcutEvent",
+        "QShowEvent",
+        "QStandardItem",
+        "QStandardItemModel",
+        "QStatusTipEvent",
+        "QSyntaxHighlighter",
+        "QTabletEvent",
+        "QTextBlock",
+        "QTextBlockFormat",
+        "QTextBlockGroup",
+        "QTextBlockUserData",
+        "QTextCharFormat",
+        "QTextCursor",
+        "QTextDocument",
+        "QTextDocumentFragment",
+        "QTextFormat",
+        "QTextFragment",
+        "QTextFrame",
+        "QTextFrameFormat",
+        "QTextImageFormat",
+        "QTextInlineObject",
+        "QTextItem",
+        "QTextLayout",
+        "QTextLength",
+        "QTextLine",
+        "QTextList",
+        "QTextListFormat",
+        "QTextObject",
+        "QTextObjectInterface",
+        "QTextOption",
+        "QTextTable",
+        "QTextTableCell",
+        "QTextTableCellFormat",
+        "QTextTableFormat",
+        "QTransform",
+        "QValidator",
+        "QVector2D",
+        "QVector3D",
+        "QVector4D",
+        "QWhatsThisClickedEvent",
+        "QWheelEvent",
+        "QWindowStateChangeEvent",
+        "qAlpha",
+        "qBlue",
+        "qGray",
+        "qGreen",
+        "qIsGray",
+        "qRed",
+        "qRgb",
+        "qRgb",
+    ],
+    "QtWidgets": [
+        "QAbstractButton",
+        "QAbstractGraphicsShapeItem",
+        "QAbstractItemDelegate",
+        "QAbstractItemView",
+        "QAbstractScrollArea",
+        "QAbstractSlider",
+        "QAbstractSpinBox",
+        "QAction",
+        "QActionGroup",
+        "QApplication",
+        "QBoxLayout",
+        "QButtonGroup",
+        "QCalendarWidget",
+        "QCheckBox",
+        "QColorDialog",
+        "QColumnView",
+        "QComboBox",
+        "QCommandLinkButton",
+        "QCommonStyle",
+        "QCompleter",
+        "QDataWidgetMapper",
+        "QDateEdit",
+        "QDateTimeEdit",
+        "QDesktopWidget",
+        "QDial",
+        "QDialog",
+        "QDialogButtonBox",
+        "QDirModel",
+        "QDockWidget",
+        "QDoubleSpinBox",
+        "QErrorMessage",
+        "QFileDialog",
+        "QFileIconProvider",
+        "QFileSystemModel",
+        "QFocusFrame",
+        "QFontComboBox",
+        "QFontDialog",
+        "QFormLayout",
+        "QFrame",
+        "QGesture",
+        "QGestureEvent",
+        "QGestureRecognizer",
+        "QGraphicsAnchor",
+        "QGraphicsAnchorLayout",
+        "QGraphicsBlurEffect",
+        "QGraphicsColorizeEffect",
+        "QGraphicsDropShadowEffect",
+        "QGraphicsEffect",
+        "QGraphicsEllipseItem",
+        "QGraphicsGridLayout",
+        "QGraphicsItem",
+        "QGraphicsItemGroup",
+        "QGraphicsLayout",
+        "QGraphicsLayoutItem",
+        "QGraphicsLineItem",
+        "QGraphicsLinearLayout",
+        "QGraphicsObject",
+        "QGraphicsOpacityEffect",
+        "QGraphicsPathItem",
+        "QGraphicsPixmapItem",
+        "QGraphicsPolygonItem",
+        "QGraphicsProxyWidget",
+        "QGraphicsRectItem",
+        "QGraphicsRotation",
+        "QGraphicsScale",
+        "QGraphicsScene",
+        "QGraphicsSceneContextMenuEvent",
+        "QGraphicsSceneDragDropEvent",
+        "QGraphicsSceneEvent",
+        "QGraphicsSceneHelpEvent",
+        "QGraphicsSceneHoverEvent",
+        "QGraphicsSceneMouseEvent",
+        "QGraphicsSceneMoveEvent",
+        "QGraphicsSceneResizeEvent",
+        "QGraphicsSceneWheelEvent",
+        "QGraphicsSimpleTextItem",
+        "QGraphicsTextItem",
+        "QGraphicsTransform",
+        "QGraphicsView",
+        "QGraphicsWidget",
+        "QGridLayout",
+        "QGroupBox",
+        "QHBoxLayout",
+        "QHeaderView",
+        "QInputDialog",
+        "QItemDelegate",
+        "QItemEditorCreatorBase",
+        "QItemEditorFactory",
+        "QKeyEventTransition",
+        "QLCDNumber",
+        "QLabel",
+        "QLayout",
+        "QLayoutItem",
+        "QLineEdit",
+        "QListView",
+        "QListWidget",
+        "QListWidgetItem",
+        "QMainWindow",
+        "QMdiArea",
+        "QMdiSubWindow",
+        "QMenu",
+        "QMenuBar",
+        "QMessageBox",
+        "QMouseEventTransition",
+        "QPanGesture",
+        "QPinchGesture",
+        "QPlainTextDocumentLayout",
+        "QPlainTextEdit",
+        "QProgressBar",
+        "QProgressDialog",
+        "QPushButton",
+        "QRadioButton",
+        "QRubberBand",
+        "QScrollArea",
+        "QScrollBar",
+        "QShortcut",
+        "QSizeGrip",
+        "QSizePolicy",
+        "QSlider",
+        "QSpacerItem",
+        "QSpinBox",
+        "QSplashScreen",
+        "QSplitter",
+        "QSplitterHandle",
+        "QStackedLayout",
+        "QStackedWidget",
+        "QStatusBar",
+        "QStyle",
+        "QStyleFactory",
+        "QStyleHintReturn",
+        "QStyleHintReturnMask",
+        "QStyleHintReturnVariant",
+        "QStyleOption",
+        "QStyleOptionButton",
+        "QStyleOptionComboBox",
+        "QStyleOptionComplex",
+        "QStyleOptionDockWidget",
+        "QStyleOptionFocusRect",
+        "QStyleOptionFrame",
+        "QStyleOptionGraphicsItem",
+        "QStyleOptionGroupBox",
+        "QStyleOptionHeader",
+        "QStyleOptionMenuItem",
+        "QStyleOptionProgressBar",
+        "QStyleOptionRubberBand",
+        "QStyleOptionSizeGrip",
+        "QStyleOptionSlider",
+        "QStyleOptionSpinBox",
+        "QStyleOptionTab",
+        "QStyleOptionTabBarBase",
+        "QStyleOptionTabWidgetFrame",
+        "QStyleOptionTitleBar",
+        "QStyleOptionToolBar",
+        "QStyleOptionToolBox",
+        "QStyleOptionToolButton",
+        "QStyleOptionViewItem",
+        "QStylePainter",
+        "QStyledItemDelegate",
+        "QSwipeGesture",
+        "QSystemTrayIcon",
+        "QTabBar",
+        "QTabWidget",
+        "QTableView",
+        "QTableWidget",
+        "QTableWidgetItem",
+        "QTableWidgetSelectionRange",
+        "QTapAndHoldGesture",
+        "QTapGesture",
+        "QTextBrowser",
+        "QTextEdit",
+        "QTimeEdit",
+        "QToolBar",
+        "QToolBox",
+        "QToolButton",
+        "QToolTip",
+        "QTreeView",
+        "QTreeWidget",
+        "QTreeWidgetItem",
+        "QTreeWidgetItemIterator",
+        "QUndoCommand",
+        "QUndoGroup",
+        "QUndoStack",
+        "QUndoView",
+        "QVBoxLayout",
+        "QWhatsThis",
+        "QWidget",
+        "QWidgetAction",
+        "QWidgetItem",
+        "QWizard",
+        "QWizardPage",
+    ],
+    "QtCore": [
+        "QAbstractAnimation",
+        "QAbstractEventDispatcher",
+        "QAbstractItemModel",
+        "QAbstractListModel",
+        "QAbstractState",
+        "QAbstractTableModel",
+        "QAbstractTransition",
+        "QAnimationGroup",
+        "QBasicTimer",
+        "QBitArray",
+        "QBuffer",
+        "QByteArray",
+        "QByteArrayMatcher",
+        "QChildEvent",
+        "QCoreApplication",
+        "QCryptographicHash",
+        "QDataStream",
+        "QDate",
+        "QDateTime",
+        "QDir",
+        "QDirIterator",
+        "QDynamicPropertyChangeEvent",
+        "QEasingCurve",
+        "QElapsedTimer",
+        "QEvent",
+        "QEventLoop",
+        "QEventTransition",
+        "QFile",
+        "QFileInfo",
+        "QFileSystemWatcher",
+        "QFinalState",
+        "QGenericArgument",
+        "QGenericReturnArgument",
+        "QHistoryState",
+        "QIODevice",
+        "QLibraryInfo",
+        "QLine",
+        "QLineF",
+        "QLocale",
+        "QMargins",
+        "QMetaClassInfo",
+        "QMetaEnum",
+        "QMetaMethod",
+        "QMetaObject",
+        "QMetaProperty",
+        "QMetaType",
+        "QMimeData",
+        "QModelIndex",
+        "QMutex",
+        "QMutexLocker",
+        "QObject",
+        "QParallelAnimationGroup",
+        "QPauseAnimation",
+        "QPersistentModelIndex",
+        "QPluginLoader",
+        "QPoint",
+        "QPointF",
+        "QProcess",
+        "QProcessEnvironment",
+        "QPropertyAnimation",
+        "QReadLocker",
+        "QReadWriteLock",
+        "QRect",
+        "QRectF",
+        "QRegExp",
+        "QResource",
+        "QRunnable",
+        "QSemaphore",
+        "QSequentialAnimationGroup",
+        "QSettings",
+        "QSignalMapper",
+        "QSignalTransition",
+        "QSize",
+        "QSizeF",
+        "QSocketNotifier",
+        "QState",
+        "QStateMachine",
+        "QSysInfo",
+        "QSystemSemaphore",
+        "QTemporaryFile",
+        "QTextBoundaryFinder",
+        "QTextCodec",
+        "QTextDecoder",
+        "QTextEncoder",
+        "QTextStream",
+        "QTextStreamManipulator",
+        "QThread",
+        "QThreadPool",
+        "QTime",
+        "QTimeLine",
+        "QTimer",
+        "QTimerEvent",
+        "QTranslator",
+        "QUrl",
+        "QVariantAnimation",
+        "QWaitCondition",
+        "QWriteLocker",
+        "QXmlStreamAttribute",
+        "QXmlStreamAttributes",
+        "QXmlStreamEntityDeclaration",
+        "QXmlStreamEntityResolver",
+        "QXmlStreamNamespaceDeclaration",
+        "QXmlStreamNotationDeclaration",
+        "QXmlStreamReader",
+        "QXmlStreamWriter",
+        "Qt",
+        "QtCriticalMsg",
+        "QtDebugMsg",
+        "QtFatalMsg",
+        "QtMsgType",
+        "QtSystemMsg",
+        "QtWarningMsg",
+        "qAbs",
+        "qAddPostRoutine",
+        "qChecksum",
+        "qCritical",
+        "qDebug",
+        "qFatal",
+        "qFuzzyCompare",
+        "qIsFinite",
+        "qIsInf",
+        "qIsNaN",
+        "qIsNull",
+        "qRegisterResourceData",
+        "qUnregisterResourceData",
+        "qVersion",
+        "qWarning",
+        "qrand",
+        "qsrand",
+    ],
+    "QtXml": [
+        "QDomAttr",
+        "QDomCDATASection",
+        "QDomCharacterData",
+        "QDomComment",
+        "QDomDocument",
+        "QDomDocumentFragment",
+        "QDomDocumentType",
+        "QDomElement",
+        "QDomEntity",
+        "QDomEntityReference",
+        "QDomImplementation",
+        "QDomNamedNodeMap",
+        "QDomNode",
+        "QDomNodeList",
+        "QDomNotation",
+        "QDomProcessingInstruction",
+        "QDomText",
+        "QXmlAttributes",
+        "QXmlContentHandler",
+        "QXmlDTDHandler",
+        "QXmlDeclHandler",
+        "QXmlDefaultHandler",
+        "QXmlEntityResolver",
+        "QXmlErrorHandler",
+        "QXmlInputSource",
+        "QXmlLexicalHandler",
+        "QXmlLocator",
+        "QXmlNamespaceSupport",
+        "QXmlParseException",
+        "QXmlReader",
+        "QXmlSimpleReader"
+    ],
+    "QtHelp": [
+        "QHelpContentItem",
+        "QHelpContentModel",
+        "QHelpContentWidget",
+        "QHelpEngine",
+        "QHelpEngineCore",
+        "QHelpIndexModel",
+        "QHelpIndexWidget",
+        "QHelpSearchEngine",
+        "QHelpSearchQuery",
+        "QHelpSearchQueryWidget",
+        "QHelpSearchResultWidget"
+    ],
+    "QtNetwork": [
+        "QAbstractNetworkCache",
+        "QAbstractSocket",
+        "QAuthenticator",
+        "QHostAddress",
+        "QHostInfo",
+        "QLocalServer",
+        "QLocalSocket",
+        "QNetworkAccessManager",
+        "QNetworkAddressEntry",
+        "QNetworkCacheMetaData",
+        "QNetworkConfiguration",
+        "QNetworkConfigurationManager",
+        "QNetworkCookie",
+        "QNetworkCookieJar",
+        "QNetworkDiskCache",
+        "QNetworkInterface",
+        "QNetworkProxy",
+        "QNetworkProxyFactory",
+        "QNetworkProxyQuery",
+        "QNetworkReply",
+        "QNetworkRequest",
+        "QNetworkSession",
+        "QSsl",
+        "QTcpServer",
+        "QTcpSocket",
+        "QUdpSocket"
+    ],
+    "QtOpenGL": [
+        "QGL",
+        "QGLContext",
+        "QGLFormat",
+        "QGLWidget"
+    ]
+}
+
+
+"""Misplaced members
+
+These members from the original submodule are misplaced relative PySide2
+
+"""
+_misplaced_members = {
+    "PySide2": {
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtCore.Property": "QtCore.Property",
+        "QtCore.Signal": "QtCore.Signal",
+        "QtCore.Slot": "QtCore.Slot",
+        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtCore.QItemSelection": "QtCore.QItemSelection",
+        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
+    },
+    "PyQt5": {
+        "QtCore.pyqtProperty": "QtCore.Property",
+        "QtCore.pyqtSignal": "QtCore.Signal",
+        "QtCore.pyqtSlot": "QtCore.Slot",
+        "QtCore.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtCore.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtCore.QStringListModel": "QtCore.QStringListModel",
+        "QtCore.QItemSelection": "QtCore.QItemSelection",
+        "QtCore.QItemSelectionModel": "QtCore.QItemSelectionModel",
+    },
+    "PySide": {
+        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtGui.QItemSelection": "QtCore.QItemSelection",
+        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.Property": "QtCore.Property",
+        "QtCore.Signal": "QtCore.Signal",
+        "QtCore.Slot": "QtCore.Slot",
+
+    },
+    "PyQt4": {
+        "QtGui.QAbstractProxyModel": "QtCore.QAbstractProxyModel",
+        "QtGui.QSortFilterProxyModel": "QtCore.QSortFilterProxyModel",
+        "QtGui.QItemSelection": "QtCore.QItemSelection",
+        "QtGui.QStringListModel": "QtCore.QStringListModel",
+        "QtGui.QItemSelectionModel": "QtCore.QItemSelectionModel",
+        "QtCore.pyqtProperty": "QtCore.Property",
+        "QtCore.pyqtSignal": "QtCore.Signal",
+        "QtCore.pyqtSlot": "QtCore.Slot",
+    }
+}
+
+""" Compatibility Members
+
+This dictionary is used to build Qt.QtCompat objects that provide a consistent
+interface for obsolete members, and differences in binding return values.
+
+{
+    "binding": {
+        "classname": {
+            "targetname": "binding_namespace",
+        }
+    }
+}
+"""
+_compatibility_members = {
+    "PySide2": {
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable":
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PyQt5": {
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.sectionsClickable",
+            "setSectionsClickable":
+                "QtWidgets.QHeaderView.setSectionsClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.sectionResizeMode",
+            "setSectionResizeMode":
+                "QtWidgets.QHeaderView.setSectionResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.sectionsMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setSectionsMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PySide": {
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+    "PyQt4": {
+        "QHeaderView": {
+            "sectionsClickable": "QtWidgets.QHeaderView.isClickable",
+            "setSectionsClickable": "QtWidgets.QHeaderView.setClickable",
+            "sectionResizeMode": "QtWidgets.QHeaderView.resizeMode",
+            "setSectionResizeMode": "QtWidgets.QHeaderView.setResizeMode",
+            "sectionsMovable": "QtWidgets.QHeaderView.isMovable",
+            "setSectionsMovable": "QtWidgets.QHeaderView.setMovable",
+        },
+        "QFileDialog": {
+            "getOpenFileName": "QtWidgets.QFileDialog.getOpenFileName",
+            "getOpenFileNames": "QtWidgets.QFileDialog.getOpenFileNames",
+            "getSaveFileName": "QtWidgets.QFileDialog.getSaveFileName",
+        },
+    },
+}
+
+
+def _apply_site_config():
+    try:
+        import QtSiteConfig
+    except ImportError:
+        # If no QtSiteConfig module found, no modifications
+        # to _common_members are needed.
+        pass
+    else:
+        # Provide the ability to modify the dicts used to build Qt.py
+        if hasattr(QtSiteConfig, 'update_members'):
+            QtSiteConfig.update_members(_common_members)
+
+        if hasattr(QtSiteConfig, 'update_misplaced_members'):
+            QtSiteConfig.update_misplaced_members(members=_misplaced_members)
+
+        if hasattr(QtSiteConfig, 'update_compatibility_members'):
+            QtSiteConfig.update_compatibility_members(
+                members=_compatibility_members)
+
+
+def _new_module(name):
+    return types.ModuleType(__name__ + "." + name)
+
+
+def _setup(module, extras):
+    """Install common submodules"""
+
+    Qt.__binding__ = module.__name__
+
+    for name in list(_common_members) + extras:
+        try:
+            submodule = importlib.import_module(
+                module.__name__ + "." + name)
+        except ImportError:
+            continue
+
+        setattr(Qt, "_" + name, submodule)
+
+        if name not in extras:
+            # Store reference to original binding,
+            # but don't store speciality modules
+            # such as uic or QtUiTools
+            setattr(Qt, name, _new_module(name))
+
+
+def _wrapinstance(func, ptr, base=None):
+    """Enable implicit cast of pointer to most suitable class
+
+    This behaviour is available in sip per default.
+
+    Based on http://nathanhorne.com/pyqtpyside-wrap-instance
+
+    Usage:
+        This mechanism kicks in under these circumstances.
+        1. Qt.py is using PySide 1 or 2.
+        2. A `base` argument is not provided.
+
+        See :func:`QtCompat.wrapInstance()`
+
+    Arguments:
+        func (function): Original function
+        ptr (long): Pointer to QObject in memory
+        base (QObject, optional): Base class to wrap with. Defaults to QObject,
+            which should handle anything.
+
+    """
+
+    assert isinstance(ptr, long), "Argument 'ptr' must be of type <long>"
+    assert (base is None) or issubclass(base, Qt.QtCore.QObject), (
+        "Argument 'base' must be of type <QObject>")
+
+    if base is None:
+        q_object = func(long(ptr), Qt.QtCore.QObject)
+        meta_object = q_object.metaObject()
+        class_name = meta_object.className()
+        super_class_name = meta_object.superClass().className()
+
+        if hasattr(Qt.QtWidgets, class_name):
+            base = getattr(Qt.QtWidgets, class_name)
+
+        elif hasattr(Qt.QtWidgets, super_class_name):
+            base = getattr(Qt.QtWidgets, super_class_name)
+
+        else:
+            base = Qt.QtCore.QObject
+
+    return func(long(ptr), base)
+
+
+def _reassign_misplaced_members(binding):
+    """Apply misplaced members from `binding` to Qt.py
+
+    Arguments:
+        binding (dict): Misplaced members
+
+    """
+
+    for src, dst in _misplaced_members[binding].items():
+        src_module, src_member = src.split(".")
+        dst_module, dst_member = dst.split(".")
+
+        try:
+            src_object = getattr(Qt, dst_module)
+        except AttributeError:
+            # Skip reassignment of non-existing members.
+            # This can happen if a request was made to
+            # rename a member that didn't exist, for example
+            # if QtWidgets isn't available on the target platform.
+            continue
+
+        dst_value = getattr(getattr(Qt, "_" + src_module), src_member)
+
+        setattr(
+            src_object,
+            dst_member,
+            dst_value
+        )
+
+
+def _build_compatibility_members(binding, decorators=None):
+    """Apply `binding` to QtCompat
+
+    Arguments:
+        binding (str): Top level binding in _compatibility_members.
+        decorators (dict, optional): Provides the ability to decorate the
+            original Qt methods when needed by a binding. This can be used
+            to change the returned value to a standard value. The key should
+            be the classname, the value is a dict where the keys are the
+            target method names, and the values are the decorator functions.
+
+    """
+
+    decorators = decorators or dict()
+
+    # Allow optional site-level customization of the compatibility members.
+    # This method does not need to be implemented in QtSiteConfig.
+    try:
+        import QtSiteConfig
+    except ImportError:
+        pass
+    else:
+        if hasattr(QtSiteConfig, 'update_compatibility_decorators'):
+            QtSiteConfig.update_compatibility_decorators(binding, decorators)
+
+    _QtCompat = type("QtCompat", (object,), {})
+
+    for classname, bindings in _compatibility_members[binding].items():
+        attrs = {}
+        for target, binding in bindings.items():
+            namespaces = binding.split('.')
+            try:
+                src_object = getattr(Qt, "_" + namespaces[0])
+            except AttributeError as e:
+                _log("QtCompat: AttributeError: %s" % e)
+                # Skip reassignment of non-existing members.
+                # This can happen if a request was made to
+                # rename a member that didn't exist, for example
+                # if QtWidgets isn't available on the target platform.
+                continue
+
+            # Walk down any remaining namespace getting the object assuming
+            # that if the first namespace exists the rest will exist.
+            for namespace in namespaces[1:]:
+                src_object = getattr(src_object, namespace)
+
+            # decorate the Qt method if a decorator was provided.
+            if target in decorators.get(classname, []):
+                # staticmethod must be called on the decorated method to
+                # prevent a TypeError being raised when the decorated method
+                # is called.
+                src_object = staticmethod(
+                    decorators[classname][target](src_object))
+
+            attrs[target] = src_object
+
+        # Create the QtCompat class and install it into the namespace
+        compat_class = type(classname, (_QtCompat,), attrs)
+        setattr(Qt.QtCompat, classname, compat_class)
+
+
+def _pyside2():
+    """Initialise PySide2
+
+    These functions serve to test the existence of a binding
+    along with set it up in such a way that it aligns with
+    the final step; adding members from the original binding
+    to Qt.py
+
+    """
+
+    import PySide2 as module
+    _setup(module, ["QtUiTools"])
+
+    Qt.__binding_version__ = module.__version__
+
+    try:
+        try:
+            # Before merge of PySide and shiboken
+            import shiboken2
+        except ImportError:
+            # After merge of PySide and shiboken, May 2017
+            from PySide2 import shiboken2
+
+        Qt.QtCompat.wrapInstance = (
+            lambda ptr, base=None: _wrapinstance(
+                shiboken2.wrapInstance, ptr, base)
+        )
+        Qt.QtCompat.getCppPointer = lambda object: \
+            shiboken2.getCppPointer(object)[0]
+
+    except ImportError:
+        pass  # Optional
+
+    if hasattr(Qt, "_QtUiTools"):
+        Qt.QtCompat.loadUi = _loadUi
+
+    if hasattr(Qt, "_QtCore"):
+        Qt.__qt_version__ = Qt._QtCore.qVersion()
+        Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
+
+    if hasattr(Qt, "_QtWidgets"):
+        Qt.QtCompat.setSectionResizeMode = \
+            Qt._QtWidgets.QHeaderView.setSectionResizeMode
+
+    _reassign_misplaced_members("PySide2")
+    _build_compatibility_members("PySide2")
+
+
+def _pyside():
+    """Initialise PySide"""
+
+    import PySide as module
+    _setup(module, ["QtUiTools"])
+
+    Qt.__binding_version__ = module.__version__
+
+    try:
+        try:
+            # Before merge of PySide and shiboken
+            import shiboken
+        except ImportError:
+            # After merge of PySide and shiboken, May 2017
+            from PySide import shiboken
+
+        Qt.QtCompat.wrapInstance = (
+            lambda ptr, base=None: _wrapinstance(
+                shiboken.wrapInstance, ptr, base)
+        )
+        Qt.QtCompat.getCppPointer = lambda object: \
+            shiboken.getCppPointer(object)[0]
+
+    except ImportError:
+        pass  # Optional
+
+    if hasattr(Qt, "_QtUiTools"):
+        Qt.QtCompat.loadUi = _loadUi
+
+    if hasattr(Qt, "_QtGui"):
+        setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
+        setattr(Qt, "_QtWidgets", Qt._QtGui)
+
+        Qt.QtCompat.setSectionResizeMode = Qt._QtGui.QHeaderView.setResizeMode
+
+    if hasattr(Qt, "_QtCore"):
+        Qt.__qt_version__ = Qt._QtCore.qVersion()
+        QCoreApplication = Qt._QtCore.QCoreApplication
+        Qt.QtCompat.translate = (
+            lambda context, sourceText, disambiguation, n:
+            QCoreApplication.translate(
+                context,
+                sourceText,
+                disambiguation,
+                QCoreApplication.CodecForTr,
+                n
+            )
+        )
+
+    _reassign_misplaced_members("PySide")
+    _build_compatibility_members("PySide")
+
+
+def _pyqt5():
+    """Initialise PyQt5"""
+
+    import PyQt5 as module
+    _setup(module, ["uic"])
+
+    try:
+        import sip
+        Qt.QtCompat.wrapInstance = (
+            lambda ptr, base=None: _wrapinstance(
+                sip.wrapinstance, ptr, base)
+        )
+        Qt.QtCompat.getCppPointer = lambda object: \
+            sip.unwrapinstance(object)
+
+    except ImportError:
+        pass  # Optional
+
+    if hasattr(Qt, "_uic"):
+        Qt.QtCompat.loadUi = _loadUi
+
+    if hasattr(Qt, "_QtCore"):
+        Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
+        Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
+        Qt.QtCompat.translate = Qt._QtCore.QCoreApplication.translate
+
+    if hasattr(Qt, "_QtWidgets"):
+        Qt.QtCompat.setSectionResizeMode = \
+            Qt._QtWidgets.QHeaderView.setSectionResizeMode
+
+    _reassign_misplaced_members("PyQt5")
+    _build_compatibility_members('PyQt5')
+
+
+def _pyqt4():
+    """Initialise PyQt4"""
+
+    import sip
+
+    # Validation of envivornment variable. Prevents an error if
+    # the variable is invalid since it's just a hint.
+    try:
+        hint = int(QT_SIP_API_HINT)
+    except TypeError:
+        hint = None  # Variable was None, i.e. not set.
+    except ValueError:
+        raise ImportError("QT_SIP_API_HINT=%s must be a 1 or 2")
+
+    for api in ("QString",
+                "QVariant",
+                "QDate",
+                "QDateTime",
+                "QTextStream",
+                "QTime",
+                "QUrl"):
+        try:
+            sip.setapi(api, hint or 2)
+        except AttributeError:
+            raise ImportError("PyQt4 < 4.6 isn't supported by Qt.py")
+        except ValueError:
+            actual = sip.getapi(api)
+            if not hint:
+                raise ImportError("API version already set to %d" % actual)
+            else:
+                # Having provided a hint indicates a soft constraint, one
+                # that doesn't throw an exception.
+                sys.stderr.write(
+                    "Warning: API '%s' has already been set to %d.\n"
+                    % (api, actual)
+                )
+
+    import PyQt4 as module
+    _setup(module, ["uic"])
+
+    try:
+        import sip
+        Qt.QtCompat.wrapInstance = (
+            lambda ptr, base=None: _wrapinstance(
+                sip.wrapinstance, ptr, base)
+        )
+        Qt.QtCompat.getCppPointer = lambda object: \
+            sip.unwrapinstance(object)
+
+    except ImportError:
+        pass  # Optional
+
+    if hasattr(Qt, "_uic"):
+        Qt.QtCompat.loadUi = _loadUi
+
+    if hasattr(Qt, "_QtGui"):
+        setattr(Qt, "QtWidgets", _new_module("QtWidgets"))
+        setattr(Qt, "_QtWidgets", Qt._QtGui)
+
+        Qt.QtCompat.setSectionResizeMode = \
+            Qt._QtGui.QHeaderView.setResizeMode
+
+    if hasattr(Qt, "_QtCore"):
+        Qt.__binding_version__ = Qt._QtCore.PYQT_VERSION_STR
+        Qt.__qt_version__ = Qt._QtCore.QT_VERSION_STR
+
+        QCoreApplication = Qt._QtCore.QCoreApplication
+        Qt.QtCompat.translate = (
+            lambda context, sourceText, disambiguation, n:
+            QCoreApplication.translate(
+                context,
+                sourceText,
+                disambiguation,
+                QCoreApplication.CodecForTr,
+                n)
+        )
+
+    _reassign_misplaced_members("PyQt4")
+
+    # QFileDialog QtCompat decorator
+    def _standardizeQFileDialog(some_function):
+        """Decorator that makes PyQt4 return conform to other bindings"""
+        def wrapper(*args, **kwargs):
+            ret = (some_function(*args, **kwargs))
+
+            # PyQt4 only returns the selected filename, force it to a
+            # standard return of the selected filename, and a empty string
+            # for the selected filter
+            return ret, ''
+
+        wrapper.__doc__ = some_function.__doc__
+        wrapper.__name__ = some_function.__name__
+
+        return wrapper
+
+    decorators = {
+        "QFileDialog": {
+            "getOpenFileName": _standardizeQFileDialog,
+            "getOpenFileNames": _standardizeQFileDialog,
+            "getSaveFileName": _standardizeQFileDialog,
+        }
+    }
+    _build_compatibility_members('PyQt4', decorators)
+
+
+def _none():
+    """Internal option (used in installer)"""
+
+    Mock = type("Mock", (), {"__getattr__": lambda Qt, attr: None})
+
+    Qt.__binding__ = "None"
+    Qt.__qt_version__ = "0.0.0"
+    Qt.__binding_version__ = "0.0.0"
+    Qt.QtCompat.loadUi = lambda uifile, baseinstance=None: None
+    Qt.QtCompat.setSectionResizeMode = lambda *args, **kwargs: None
+
+    for submodule in _common_members.keys():
+        setattr(Qt, submodule, Mock())
+        setattr(Qt, "_" + submodule, Mock())
+
+
+def _log(text):
+    if QT_VERBOSE:
+        sys.stdout.write(text + "\n")
+
+
+def _loadUi(uifile, baseinstance=None):
+    """Dynamically load a user interface from the given `uifile`
+
+    This function calls `uic.loadUi` if using PyQt bindings,
+    else it implements a comparable binding for PySide.
+
+    Documentation:
+        http://pyqt.sourceforge.net/Docs/PyQt5/designer.html#PyQt5.uic.loadUi
+
+    Arguments:
+        uifile (str): Absolute path to Qt Designer file.
+        baseinstance (QWidget): Instantiated QWidget or subclass thereof
+
+    Return:
+        baseinstance if `baseinstance` is not `None`. Otherwise
+        return the newly created instance of the user interface.
+
+    """
+    if hasattr(baseinstance, "layout") and baseinstance.layout():
+        message = ("QLayout: Attempting to add Layout to %s which "
+                   "already has a layout")
+        raise RuntimeError(message % (baseinstance))
+
+    if hasattr(Qt, "_uic"):
+        return Qt._uic.loadUi(uifile, baseinstance)
+
+    elif hasattr(Qt, "_QtUiTools"):
+        # Implement `PyQt5.uic.loadUi` for PySide(2)
+
+        class _UiLoader(Qt._QtUiTools.QUiLoader):
+            """Create the user interface in a base instance.
+
+            Unlike `Qt._QtUiTools.QUiLoader` itself this class does not
+            create a new instance of the top-level widget, but creates the user
+            interface in an existing instance of the top-level class if needed.
+
+            This mimics the behaviour of `PyQt5.uic.loadUi`.
+
+            """
+
+            def __init__(self, baseinstance):
+                super(_UiLoader, self).__init__(baseinstance)
+                self.baseinstance = baseinstance
+
+            def load(self, uifile, *args, **kwargs):
+                from xml.etree.ElementTree import ElementTree
+
+                # For whatever reason, if this doesn't happen then
+                # reading an invalid or non-existing .ui file throws
+                # a RuntimeError.
+                etree = ElementTree()
+                etree.parse(uifile)
+
+                widget = Qt._QtUiTools.QUiLoader.load(
+                    self, uifile, *args, **kwargs)
+
+                # Workaround for PySide 1.0.9, see issue #208
+                widget.parentWidget()
+
+                return widget
+
+            def createWidget(self, class_name, parent=None, name=""):
+                """Called for each widget defined in ui file
+
+                Overridden here to populate `baseinstance` instead.
+
+                """
+
+                if parent is None and self.baseinstance:
+                    # Supposed to create the top-level widget,
+                    # return the base instance instead
+                    return self.baseinstance
+
+                # For some reason, Line is not in the list of available
+                # widgets, but works fine, so we have to special case it here.
+                if class_name in self.availableWidgets() + ["Line"]:
+                    # Create a new widget for child widgets
+                    widget = Qt._QtUiTools.QUiLoader.createWidget(self,
+                                                                  class_name,
+                                                                  parent,
+                                                                  name)
+
+                else:
+                    raise Exception("Custom widget '%s' not supported"
+                                    % class_name)
+
+                if self.baseinstance:
+                    # Set an attribute for the new child widget on the base
+                    # instance, just like PyQt5.uic.loadUi does.
+                    setattr(self.baseinstance, name, widget)
+
+                return widget
+
+        widget = _UiLoader(baseinstance).load(uifile)
+        Qt.QtCore.QMetaObject.connectSlotsByName(widget)
+
+        return widget
+
+    else:
+        raise NotImplementedError("No implementation available for loadUi")
+
+
+def _convert(lines):
+    """Convert compiled .ui file from PySide2 to Qt.py
+
+    Arguments:
+        lines (list): Each line of of .ui file
+
+    Usage:
+        >> with open("myui.py") as f:
+        ..   lines = _convert(f.readlines())
+
+    """
+
+    def parse(line):
+        line = line.replace("from PySide2 import", "from Qt import QtCompat,")
+        line = line.replace("QtWidgets.QApplication.translate",
+                            "QtCompat.translate")
+        if "QtCore.SIGNAL" in line:
+            raise NotImplementedError("QtCore.SIGNAL is missing from PyQt5 "
+                                      "and so Qt.py does not support it: you "
+                                      "should avoid defining signals inside "
+                                      "your ui files.")
+        return line
+
+    parsed = list()
+    for line in lines:
+        line = parse(line)
+        parsed.append(line)
+
+    return parsed
+
+
+def _cli(args):
+    """Qt.py command-line interface"""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--convert",
+                        help="Path to compiled Python module, e.g. my_ui.py")
+    parser.add_argument("--compile",
+                        help="Accept raw .ui file and compile with native "
+                             "PySide2 compiler.")
+    parser.add_argument("--stdout",
+                        help="Write to stdout instead of file",
+                        action="store_true")
+    parser.add_argument("--stdin",
+                        help="Read from stdin instead of file",
+                        action="store_true")
+
+    args = parser.parse_args(args)
+
+    if args.stdout:
+        raise NotImplementedError("--stdout")
+
+    if args.stdin:
+        raise NotImplementedError("--stdin")
+
+    if args.compile:
+        raise NotImplementedError("--compile")
+
+    if args.convert:
+        sys.stdout.write("#\n"
+                         "# WARNING: --convert is an ALPHA feature.\n#\n"
+                         "# See https://github.com/mottosso/Qt.py/pull/132\n"
+                         "# for details.\n"
+                         "#\n")
+
+        #
+        # ------> Read
+        #
+        with open(args.convert) as f:
+            lines = _convert(f.readlines())
+
+        backup = "%s_backup%s" % os.path.splitext(args.convert)
+        sys.stdout.write("Creating \"%s\"..\n" % backup)
+        shutil.copy(args.convert, backup)
+
+        #
+        # <------ Write
+        #
+        with open(args.convert, "w") as f:
+            f.write("".join(lines))
+
+        sys.stdout.write("Successfully converted \"%s\"\n" % args.convert)
+
+
+def _install():
+    # Default order (customise order and content via QT_PREFERRED_BINDING)
+    default_order = ("PySide2", "PyQt5", "PySide", "PyQt4")
+    preferred_order = list(
+        b for b in QT_PREFERRED_BINDING.split(os.pathsep) if b
+    )
+
+    order = preferred_order or default_order
+
+    available = {
+        "PySide2": _pyside2,
+        "PyQt5": _pyqt5,
+        "PySide": _pyside,
+        "PyQt4": _pyqt4,
+        "None": _none
+    }
+
+    _log("Order: '%s'" % "', '".join(order))
+
+    # Allow site-level customization of the available modules.
+    _apply_site_config()
+
+    found_binding = False
+    for name in order:
+        _log("Trying %s" % name)
+
+        try:
+            available[name]()
+            found_binding = True
+            break
+
+        except ImportError as e:
+            _log("ImportError: %s" % e)
+
+        except KeyError:
+            _log("ImportError: Preferred binding '%s' not found." % name)
+
+    if not found_binding:
+        # If not binding were found, throw this error
+        raise ImportError("No Qt binding were found.")
+
+    # Install individual members
+    for name, members in _common_members.items():
+        try:
+            their_submodule = getattr(Qt, "_%s" % name)
+        except AttributeError:
+            continue
+
+        our_submodule = getattr(Qt, name)
+
+        # Enable import *
+        __all__.append(name)
+
+        # Enable direct import of submodule,
+        # e.g. import Qt.QtCore
+        sys.modules[__name__ + "." + name] = our_submodule
+
+        for member in members:
+            # Accept that a submodule may miss certain members.
+            try:
+                their_member = getattr(their_submodule, member)
+            except AttributeError:
+                _log("'%s.%s' was missing." % (name, member))
+                continue
+
+            setattr(our_submodule, member, their_member)
+
+    # Backwards compatibility
+    if hasattr(Qt.QtCompat, 'loadUi'):
+        Qt.QtCompat.load_ui = Qt.QtCompat.loadUi
+
+
+_install()
+
+# Setup Binding Enum states
+Qt.IsPySide2 = Qt.__binding__ == 'PySide2'
+Qt.IsPyQt5 = Qt.__binding__ == 'PyQt5'
+Qt.IsPySide = Qt.__binding__ == 'PySide'
+Qt.IsPyQt4 = Qt.__binding__ == 'PyQt4'
+
+"""Augment QtCompat
+
+QtCompat contains wrappers and added functionality
+to the original bindings, such as the CLI interface
+and otherwise incompatible members between bindings,
+such as `QHeaderView.setSectionResizeMode`.
+
+"""
+
+Qt.QtCompat._cli = _cli
+Qt.QtCompat._convert = _convert
+
+# Enable command-line interface
+if __name__ == "__main__":
+    _cli(sys.argv[1:])
+
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2017 Marcus Ottosson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# In PySide(2), loadUi does not exist, so we implement it
+#
+# `_UiLoader` is adapted from the qtpy project, which was further influenced
+# by qt-helpers which was released under a 3-clause BSD license which in turn
+# is based on a solution at:
+#
+# - https://gist.github.com/cpbotha/1b42a20c8f3eb9bb7cb8
+#
+# The License for this code is as follows:
+#
+# qt-helpers - a common front-end to various Qt modules
+#
+# Copyright (c) 2015, Chris Beaumont and Thomas Robitaille
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of the Glue project nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Which itself was based on the solution at
+#
+# https://gist.github.com/cpbotha/1b42a20c8f3eb9bb7cb8
+#
+# which was released under the MIT license:
+#
+# Copyright (c) 2011 Sebastian Wiesner <lunaryorn@gmail.com>
+# Modifications by Charl Botha <cpbotha@vxlabs.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files
+# (the "Software"),to deal in the Software without restriction,
+# including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/anim_picker/__init__.py
+++ b/anim_picker/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of "anim_picker" and covered by the LGPLv3 or later,
 # read COPYING and COPYING.LESSER for details.
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 def load(edit=False, multi=False):
     '''Fast load method

--- a/anim_picker/gui.py
+++ b/anim_picker/gui.py
@@ -19,7 +19,7 @@ from handlers import maya_handlers
 from handlers import python_handlers
 
 from handlers import qt_handlers
-from handlers.qt_handlers import QtCore, QtGui, QtOpenGL
+from handlers.qt_handlers import QtCore, QtWidgets, QtOpenGL, QtWidgets
 
 from handlers import __EDIT_MODE__
 from handlers import __SELECTION__
@@ -44,17 +44,17 @@ def get_images_folder_path():
 #===============================================================================
 # Custom Widgets ---
 #===============================================================================      
-class CallbackButton(QtGui.QPushButton):
+class CallbackButton(QtWidgets.QPushButton):
     '''Dynamic callback button
     '''
     def __init__(self, callback=None, *args, **kwargs):
-        QtGui.QPushButton.__init__(self)
+        QtWidgets.QPushButton.__init__(self)
         self.callback   =   callback
         self.args       =   args
         self.kwargs     =   kwargs
         
         # Connect event
-        self.connect(self, QtCore.SIGNAL("clicked()"), self.click_event)
+        self.clicked.connect(self.click_event)
         
         # Set tooltip
         if hasattr(self.callback, '__doc__') and self.callback.__doc__:
@@ -66,18 +66,18 @@ class CallbackButton(QtGui.QPushButton):
         self.callback(*self.args, **self.kwargs)
         
 
-class CallbackComboBox(QtGui.QComboBox):
+class CallbackComboBox(QtWidgets.QComboBox):
     '''Dynamic combo box object
     '''
     def __init__(self, callback=None, status_tip=None, *args, **kwargs):
-        QtGui.QComboBox.__init__(self)
+        QtWidgets.QComboBox.__init__(self)
         self.callback = callback
         self.args = args
         self.kwargs = kwargs
         if status_tip:
             self.setStatusTip(status_tip)
         
-        self.connect(self, QtCore.SIGNAL('currentIndexChanged(int)'), self.index_change_event)
+        self.currentIndexChanged.connect(self.index_change_event)
     
     def index_change_event(self, index):
         if not self.callback:
@@ -85,14 +85,14 @@ class CallbackComboBox(QtGui.QComboBox):
         self.callback(index=index, *self.args, **self.kwargs)
         
         
-class CallBackSpinBox(QtGui.QSpinBox):
+class CallBackSpinBox(QtWidgets.QSpinBox):
     def __init__(self,
                  callback,
                  value=0,
                  min=0,
                  max=9999,
                  *args, **kwargs):
-        QtGui.QSpinBox.__init__(self)
+        QtWidgets.QSpinBox.__init__(self)
         self.callback = callback
         self.args = args
         self.kwargs = kwargs
@@ -102,7 +102,7 @@ class CallBackSpinBox(QtGui.QSpinBox):
         self.setValue(value)
         
         # Signals
-        self.connect(self, QtCore.SIGNAL("valueChanged(int)"), self.valueChangedEvent)
+        self.valueChanged.connect(self.valueChangedEvent)
     
     def valueChangedEvent(self, value):
         if not self.callback:
@@ -110,7 +110,7 @@ class CallBackSpinBox(QtGui.QSpinBox):
         self.callback(value=value, *self.args, **self.kwargs)
 
 
-class CallBackDoubleSpinBox(QtGui.QDoubleSpinBox):
+class CallBackDoubleSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self,
                  callback,
                  value=0,
@@ -118,7 +118,7 @@ class CallBackDoubleSpinBox(QtGui.QDoubleSpinBox):
                  max=9999,
                  *args,
                  **kwargs):
-        QtGui.QDoubleSpinBox.__init__(self)
+        QtWidgets.QDoubleSpinBox.__init__(self)
         self.callback = callback
         self.args = args
         self.kwargs = kwargs
@@ -128,16 +128,16 @@ class CallBackDoubleSpinBox(QtGui.QDoubleSpinBox):
         self.setValue(value)
         
         # Signals
-        self.connect(self, QtCore.SIGNAL("valueChanged(double)"), self.valueChangedEvent)
+        self.valueChanged.connect(self.valueChangedEvent)
     
     def valueChangedEvent(self, value):
         if not self.callback:
             return
         self.callback(value=value, *self.args, **self.kwargs)
         
-class CallbackLineEdit(QtGui.QLineEdit):
+class CallbackLineEdit(QtWidgets.QLineEdit):
     def __init__(self, callback, text=None, *args, **kwargs):
-        QtGui.QLineEdit.__init__(self)
+        QtWidgets.QLineEdit.__init__(self)
         self.callback   =   callback
         self.args = args
         self.kwargs = kwargs
@@ -147,7 +147,7 @@ class CallbackLineEdit(QtGui.QLineEdit):
             self.setText(text)
         
         # Signals
-        self.connect(self, QtCore.SIGNAL("returnPressed()"), self.return_pressed_event)
+        self.returnPressed.connect(self.return_pressed_event)
         
     def return_pressed_event(self):
         '''Will return text on return press
@@ -155,16 +155,16 @@ class CallbackLineEdit(QtGui.QLineEdit):
         self.callback(text=self.text(), *self.args, **self.kwargs)
         
         
-class CallbackListWidget(QtGui.QListWidget):
+class CallbackListWidget(QtWidgets.QListWidget):
     '''Dynamic List Widget object
     '''
     def __init__(self, callback=None, *args, **kwargs):
-        QtGui.QListWidget.__init__(self)
+        QtWidgets.QListWidget.__init__(self)
         self.callback   =   callback
         self.args       =   args
         self.kwargs     =   kwargs
         
-        self.connect(self, QtCore.SIGNAL('itemDoubleClicked (QListWidgetItem *)'), self.double_click_event)
+        self.itemDoubleClicked.connect(self.double_click_event)
         
         # Set selection mode to multi
         self.setSelectionMode(self.ExtendedSelection)
@@ -175,7 +175,7 @@ class CallbackListWidget(QtGui.QListWidget):
         self.callback(item=item, *self.args, **self.kwargs)
      
      
-class CallbackCheckBoxWidget(QtGui.QCheckBox):
+class CallbackCheckBoxWidget(QtWidgets.QCheckBox):
     '''Dynamic CheckBox Widget object
     '''
     def __init__(self,
@@ -184,7 +184,7 @@ class CallbackCheckBoxWidget(QtGui.QCheckBox):
                  label=None,
                  *args,
                  **kwargs):
-        QtGui.QCheckBox.__init__(self)
+        QtWidgets.QCheckBox.__init__(self)
         self.callback = callback
         self.args = args
         self.kwargs = kwargs
@@ -194,7 +194,7 @@ class CallbackCheckBoxWidget(QtGui.QCheckBox):
             self.setCheckState(QtCore.Qt.Checked)
         self.setText(label or '')
         
-        self.connect(self, QtCore.SIGNAL("toggled(bool)"), self.toggled_event)
+        self.toggled.connect(self.toggled_event)
 
     def toggled_event(self, value):
         if not self.callback:
@@ -203,29 +203,29 @@ class CallbackCheckBoxWidget(QtGui.QCheckBox):
         self.callback(*self.args, **self.kwargs) 
 
 
-class CallbackRadioButtonWidget(QtGui.QRadioButton):
+class CallbackRadioButtonWidget(QtWidgets.QRadioButton):
     '''Dynamic callback radioButton
     '''
     def __init__(self, name_value, callback, checked=False):
-        QtGui.QRadioButton.__init__(self)
+        QtWidgets.QRadioButton.__init__(self)
         self.name_value = name_value
         self.callback = callback
         
         self.setChecked(checked)
-            
-        self.connect(self, QtCore.SIGNAL("clicked()"), self.click_event)
+
+        self.clicked.connect(self.click_event)
         
     def click_event(self):
         self.callback(self.name_value)
                 
 
-class CtrlListWidgetItem(QtGui.QListWidgetItem):
+class CtrlListWidgetItem(QtWidgets.QListWidgetItem):
     '''
     List widget item for influence list
     will handle checks, color feedbacks and edits
     '''
     def __init__(self, index=0, text=None):
-        QtGui.QListWidgetItem.__init__(self)
+        QtWidgets.QListWidgetItem.__init__(self)
         
         self.index = index
         if text:
@@ -239,7 +239,7 @@ class CtrlListWidgetItem(QtGui.QListWidgetItem):
             return None
         
         # Run default setText action
-        QtGui.QListWidgetItem.setText(self, text)
+        QtWidgets.QListWidgetItem.setText(self, text)
         
         # Set color status
         self.set_color_status()
@@ -274,14 +274,14 @@ class CtrlListWidgetItem(QtGui.QListWidgetItem):
         self.setForeground(brush)
  
  
-class ContextMenuTabWidget(QtGui.QTabWidget):
+class ContextMenuTabWidget(QtWidgets.QTabWidget):
     '''Custom tab widget with specific context menu support
     '''
     def __init__(self,
                  parent,
                  main_window=None,
                  *args, **kwargs):
-        QtGui.QTabWidget.__init__(self, parent, *args, **kwargs)
+        QtWidgets.QTabWidget.__init__(self, parent, *args, **kwargs)
         self.main_window = main_window
         
     def contextMenuEvent(self, event):
@@ -292,18 +292,18 @@ class ContextMenuTabWidget(QtGui.QTabWidget):
             return
             
         # Init context menu
-        menu = QtGui.QMenu(self)
+        menu = QtWidgets.QMenu(self)
         
         # Build context menu
-        rename_action = QtGui.QAction("Rename", None)
+        rename_action = QtWidgets.QAction("Rename", None)
         rename_action.triggered.connect(self.rename_event)
         menu.addAction(rename_action)
         
-        add_action = QtGui.QAction("Add Tab", None)
+        add_action = QtWidgets.QAction("Add Tab", None)
         add_action.triggered.connect(self.add_tab_event)
         menu.addAction(add_action)
         
-        remove_action = QtGui.QAction("Remove Tab", None)
+        remove_action = QtWidgets.QAction("Remove Tab", None)
         remove_action.triggered.connect(self.remove_tab_event)
         menu.addAction(remove_action)
         
@@ -326,10 +326,10 @@ class ContextMenuTabWidget(QtGui.QTabWidget):
         index = self.currentIndex()
         
         # Open input window
-        name, ok = QtGui.QInputDialog.getText(self,
+        name, ok = QtWidgets.QInputDialog.getText(self,
                                               self.tr("Tab name"),
                                               self.tr('New name'),
-                                              QtGui.QLineEdit.Normal,
+                                              QtWidgets.QLineEdit.Normal,
                                               self.tr(self.tabText(index)) )
         if not (ok and name):
             return
@@ -341,10 +341,10 @@ class ContextMenuTabWidget(QtGui.QTabWidget):
         '''Will open dialog to get tab name and create a new tab
         '''
         # Open input window
-        name, ok = QtGui.QInputDialog.getText(self,
+        name, ok = QtWidgets.QInputDialog.getText(self,
                                               self.tr("Create new tab"),
                                               self.tr('Tab name'),
-                                              QtGui.QLineEdit.Normal,
+                                              QtWidgets.QLineEdit.Normal,
                                               self.tr('') )
         if not (ok and name):
             return
@@ -362,11 +362,11 @@ class ContextMenuTabWidget(QtGui.QTabWidget):
         index = self.currentIndex()
         
         # Open confirmation
-        reply = QtGui.QMessageBox.question(self, 'Delete',
+        reply = QtWidgets.QMessageBox.question(self, 'Delete',
                                            "Delete tab '%s'?"%self.tabText(index),
-                                           QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-                                           QtGui.QMessageBox.No)
-        if reply == QtGui.QMessageBox.No:
+                                           QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                                           QtWidgets.QMessageBox.No)
+        if reply == QtWidgets.QMessageBox.No:
             return
         
         # Remove tab
@@ -418,12 +418,12 @@ class ContextMenuTabWidget(QtGui.QTabWidget):
                 view.set_data(tab_content)
     
         
-class BackgroundWidget(QtGui.QLabel):
+class BackgroundWidget(QtWidgets.QLabel):
     '''QLabel widget to support background options for tabs.
     '''
     def __init__(self,
                  parent=None):
-        QtGui.QLabel.__init__(self, parent )
+        QtWidgets.QLabel.__init__(self, parent )
         
         self.setBackgroundRole(QtGui.QPalette.Base)
         self.background = None
@@ -432,7 +432,7 @@ class BackgroundWidget(QtGui.QLabel):
         assert os.path.exists(path), 'Could not find file%s'%path
     
     def resizeEvent(self, event):
-        QtGui.QLabel.resizeEvent(self, event)
+        QtWidgets.QLabel.resizeEvent(self, event)
         self._set_stylesheet_background()
     
     def _set_stylesheet_background(self):
@@ -464,7 +464,7 @@ class BackgroundWidget(QtGui.QLabel):
     def file_dialog(self):
         '''Get file dialog window starting in default folder
         '''
-        file_path = QtGui.QFileDialog.getOpenFileName(self,
+        file_path = QtWidgets.QFileDialog.getOpenFileName(self,
                                                       'Choose picture',
                                                       get_images_folder_path())
         # Filter return result (based on qt version)
@@ -524,15 +524,15 @@ class SnapshotWidget(BackgroundWidget):
             return
         
         # Init context menu
-        menu = QtGui.QMenu(self)
+        menu = QtWidgets.QMenu(self)
         
         # Add choose action
-        choose_action = QtGui.QAction("Select Picture", None)
+        choose_action = QtWidgets.QAction("Select Picture", None)
         choose_action.triggered.connect(self.select_image)
         menu.addAction(choose_action)
         
         # Add reset action
-        reset_action = QtGui.QAction("Reset", None)
+        reset_action = QtWidgets.QAction("Reset", None)
         reset_action.triggered.connect(self.reset_image)
         menu.addAction(reset_action)
             
@@ -565,7 +565,7 @@ class SnapshotWidget(BackgroundWidget):
         return self.background
 
 
-class OverlayWidget(QtGui.QWidget):
+class OverlayWidget(QtWidgets.QWidget):
     '''
     Transparent overlay type widget
     
@@ -577,7 +577,7 @@ class OverlayWidget(QtGui.QWidget):
     
     '''
     def __init__(self, parent=None):
-        QtGui.QWidget.__init__(self, parent)
+        QtWidgets.QWidget.__init__(self, parent)
         
         self.set_default_background_color()
         self.setup()
@@ -595,7 +595,7 @@ class OverlayWidget(QtGui.QWidget):
 
     def setup(self):
         # Add default layout
-        self.layout = QtGui.QVBoxLayout(self)
+        self.layout = QtWidgets.QVBoxLayout(self)
         
         # Hide by default
         self.hide()
@@ -648,7 +648,7 @@ class State():
         self.state = state
         
     
-class DataCopyDialog(QtGui.QDialog):
+class DataCopyDialog(QtWidgets.QDialog):
     '''PickerItem data copying dialog handler
     '''
     __DATA__ = dict()
@@ -677,7 +677,7 @@ class DataCopyDialog(QtGui.QDialog):
     
     def __init__(self,
                  parent=None):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         self.apply = False
         self.setup()
         
@@ -687,7 +687,7 @@ class DataCopyDialog(QtGui.QDialog):
         self.setWindowTitle('Copy/Paste')
         
         # Add layout
-        self.main_layout = QtGui.QVBoxLayout(self)
+        self.main_layout = QtWidgets.QVBoxLayout(self)
         
         # Add data field options
         for state in self.__STATES__:
@@ -698,7 +698,7 @@ class DataCopyDialog(QtGui.QDialog):
             self.main_layout.addWidget(cb)
         
         # Add buttons
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
         self.main_layout.addLayout(btn_layout)
         
         ok_btn = CallbackButton(callback=self.accept_event)
@@ -781,7 +781,7 @@ class DataCopyDialog(QtGui.QDialog):
         return data
     
 
-class CustomScriptEditDialog(QtGui.QDialog):
+class CustomScriptEditDialog(QtWidgets.QDialog):
     '''Custom python script window (used for custom picker item action and context menu)
     '''
     __TITLE__ = 'Custom script'
@@ -790,7 +790,7 @@ class CustomScriptEditDialog(QtGui.QDialog):
                  parent=None,
                  cmd=None,
                  item=None):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         
         self.cmd = cmd
         self.picker_item = item
@@ -816,10 +816,10 @@ class CustomScriptEditDialog(QtGui.QDialog):
         self.setWindowTitle(self.__TITLE__)
         
         # Add layout
-        self.main_layout = QtGui.QVBoxLayout(self)
+        self.main_layout = QtWidgets.QVBoxLayout(self)
         
         # Add cmd txt field
-        self.cmd_widget = QtGui.QTextEdit()
+        self.cmd_widget = QtWidgets.QTextEdit()
         if self.cmd:
             self.cmd_widget.setText(self.cmd)
         else:
@@ -828,7 +828,7 @@ class CustomScriptEditDialog(QtGui.QDialog):
         self.main_layout.addWidget(self.cmd_widget)
         
         # Add buttons
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
         self.main_layout.addLayout(btn_layout)
         
         ok_btn = CallbackButton(callback=self.accept_event)
@@ -913,13 +913,13 @@ class CustomMenuEditDialog(CustomScriptEditDialog):
         CustomScriptEditDialog.setup(self)
         
         # Add name line edit
-        name_layout = QtGui.QHBoxLayout(self)
+        name_layout = QtWidgets.QHBoxLayout(self)
         
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText('Name')
         name_layout.addWidget(label)
         
-        self.name_widget = QtGui.QLineEdit()
+        self.name_widget = QtWidgets.QLineEdit()
         if self.name:
             self.name_widget.setText(self.name)
         name_layout.addWidget(self.name_widget)
@@ -930,7 +930,7 @@ class CustomMenuEditDialog(CustomScriptEditDialog):
         '''Accept button event, check for name
         '''
         if not self.name_widget.text():
-            QtGui.QMessageBox.warning(self,
+            QtWidgets.QMessageBox.warning(self,
                                       "Warning",
                                       "You need to specify a menu name")
             return
@@ -960,14 +960,14 @@ class CustomMenuEditDialog(CustomScriptEditDialog):
         return win.get_values()
     
 
-class SearchAndReplaceDialog(QtGui.QDialog):
+class SearchAndReplaceDialog(QtWidgets.QDialog):
     '''Search and replace dialog window
     '''
     __SEARCH_STR__ = '^L_'
     __REPLACE_STR__ = 'R_'
     
     def __init__(self, parent=None):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         
         self.apply = False
         self.setup()
@@ -978,19 +978,19 @@ class SearchAndReplaceDialog(QtGui.QDialog):
         self.setWindowTitle('Search And Replace')
         
         # Add layout
-        self.main_layout = QtGui.QVBoxLayout(self)
+        self.main_layout = QtWidgets.QVBoxLayout(self)
         
         # Add line edits
-        self.search_widget = QtGui.QLineEdit()
+        self.search_widget = QtWidgets.QLineEdit()
         self.search_widget.setText(self.__SEARCH_STR__)
         self.main_layout.addWidget(self.search_widget)
         
-        self.replace_widget = QtGui.QLineEdit()
+        self.replace_widget = QtWidgets.QLineEdit()
         self.replace_widget.setText(self.__REPLACE_STR__)
         self.main_layout.addWidget(self.replace_widget)
     
         # Add buttons
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
         self.main_layout.addLayout(btn_layout)
         
         ok_btn = CallbackButton(callback=self.accept_event)
@@ -1039,7 +1039,7 @@ class SearchAndReplaceDialog(QtGui.QDialog):
         return win.get_values()
 
         
-class OrderedGraphicsScene(QtGui.QGraphicsScene):
+class OrderedGraphicsScene(QtWidgets.QGraphicsScene):
     '''
     Custom QGraphicsScene with x/y axis line options for origin feedback in edition mode
     (provides a center reference to work from, view will fit what ever is the content in use mode).
@@ -1050,7 +1050,7 @@ class OrderedGraphicsScene(QtGui.QGraphicsScene):
     __DEFAULT_SCENE_HEIGHT__ = 600
     
     def __init__(self, parent=None):
-        QtGui.QGraphicsScene.__init__(self, parent=parent)
+        QtWidgets.QGraphicsScene.__init__(self, parent=parent)
         
         self.set_default_size()
         self._z_index = 0
@@ -1091,7 +1091,7 @@ class OrderedGraphicsScene(QtGui.QGraphicsScene):
     def clear(self):
         '''Reset default z index on clear
         '''
-        QtGui.QGraphicsScene.clear(self)
+        QtWidgets.QGraphicsScene.clear(self)
         self._z_index = 0
         
     def set_picker_items(self, items):
@@ -1099,7 +1099,7 @@ class OrderedGraphicsScene(QtGui.QGraphicsScene):
         '''
         self.clear()
         for item in items:
-            QtGui.QGraphicsScene.addItem(self, item)
+            QtWidgets.QGraphicsScene.addItem(self, item)
             self.set_z_value(item)
         self.add_axis_lines()
             
@@ -1123,11 +1123,11 @@ class OrderedGraphicsScene(QtGui.QGraphicsScene):
     def addItem(self, item):
         '''Overload to keep axis on top
         '''    
-        QtGui.QGraphicsScene.addItem(self, item)
+        QtWidgets.QGraphicsScene.addItem(self, item)
         self.set_z_value(item)
         
 
-class GraphicViewWidget(QtGui.QGraphicsView):
+class GraphicViewWidget(QtWidgets.QGraphicsView):
     '''Graphic view widget that display the "polygons" picker items 
     '''
     __DEFAULT_SCENE_WIDTH__ = 400
@@ -1136,7 +1136,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
     def __init__(self,
                  namespace=None,
                  main_window=None):
-        QtGui.QGraphicsView.__init__(self)
+        QtWidgets.QGraphicsView.__init__(self)
         
         self.setScene(OrderedGraphicsScene())
         
@@ -1182,7 +1182,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
     def mousePressEvent(self, event):
         '''Overload to clear selection on empty area
         '''
-        QtGui.QGraphicsView.mousePressEvent(self, event)
+        QtWidgets.QGraphicsView.mousePressEvent(self, event)
         if event.buttons() == QtCore.Qt.LeftButton:
             scene_pos = self.mapToScene(event.pos())
             
@@ -1203,7 +1203,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
 #        self.drag_active = True            
     
     def mouseMoveEvent(self, event):
-        result = QtGui.QGraphicsView.mouseMoveEvent(self, event)
+        result = QtWidgets.QGraphicsView.mouseMoveEvent(self, event)
         
         if self.pan_active:
             current_center = self.get_center_pos()
@@ -1216,7 +1216,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         
         
     def mouseReleaseEvent(self, event):
-        result = QtGui.QGraphicsView.mouseReleaseEvent(self, event)
+        result = QtWidgets.QGraphicsView.mouseReleaseEvent(self, event)
 
 #        # Area selection
 #        if (self.drag_active and event.button() == QtCore.Qt.LeftButton):
@@ -1255,7 +1255,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         '''Wheel event overload to add zoom support
         '''
         # Run default event
-        QtGui.QGraphicsView.wheelEvent(self, event)
+        QtWidgets.QGraphicsView.wheelEvent(self, event)
         
         # Define zoom factor
         factor = 1.1
@@ -1280,42 +1280,42 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         picker_item = self.itemAt(event.pos())
         if picker_item:
             # Run default method that call on childs
-            return QtGui.QGraphicsView.contextMenuEvent(self, event)
+            return QtWidgets.QGraphicsView.contextMenuEvent(self, event)
         
         # Init context menu
-        menu = QtGui.QMenu(self)
+        menu = QtWidgets.QMenu(self)
         
         # Build Edit move options
         if __EDIT_MODE__.get():
-            add_action = QtGui.QAction("Add Item", None)
+            add_action = QtWidgets.QAction("Add Item", None)
             add_action.triggered.connect(self.add_picker_item)
             menu.addAction(add_action)
             
-            toggle_handles_action = QtGui.QAction("Toggle all handles", None)
+            toggle_handles_action = QtWidgets.QAction("Toggle all handles", None)
             toggle_handles_action.triggered.connect(self.toggle_all_handles_event)
             menu.addAction(toggle_handles_action)
             
             menu.addSeparator()
             
-            background_action = QtGui.QAction("Set background image", None)
+            background_action = QtWidgets.QAction("Set background image", None)
             background_action.triggered.connect(self.set_background_event)
             menu.addAction(background_action)
             
-            reset_background_action = QtGui.QAction("Reset background", None)
+            reset_background_action = QtWidgets.QAction("Reset background", None)
             reset_background_action.triggered.connect(self.reset_background_event)
             menu.addAction(reset_background_action)
             
             menu.addSeparator()
         
         if __EDIT_MODE__.get_main():
-            toggle_mode_action = QtGui.QAction("Toggle Mode", None)
+            toggle_mode_action = QtWidgets.QAction("Toggle Mode", None)
             toggle_mode_action.triggered.connect(self.toggle_mode_event)
             menu.addAction(toggle_mode_action)
     
             menu.addSeparator()        
         
         # Common actions
-        reset_view_action = QtGui.QAction("Reset view", None)
+        reset_view_action = QtWidgets.QAction("Reset view", None)
         reset_view_action.triggered.connect(self.fit_scene_content)
         menu.addAction(reset_view_action)
 
@@ -1329,7 +1329,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         self.fit_scene_content()
         
         # Run default resizeEvent
-        return QtGui.QGraphicsView.resizeEvent(self, *args, **kwargs)
+        return QtWidgets.QGraphicsView.resizeEvent(self, *args, **kwargs)
         
     def fit_scene_content(self):
         '''Will fit scene content to view, by scaling it
@@ -1414,7 +1414,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         '''Set background image pick dialog window
         '''
         # Open file dialog
-        file_path = QtGui.QFileDialog.getOpenFileName(self,
+        file_path = QtWidgets.QFileDialog.getOpenFileName(self,
                                                       'Choose a background',
                                                       get_images_folder_path())
         
@@ -1505,7 +1505,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         '''Default method override to draw view custom background image
         '''
         # Run default method
-        result = QtGui.QGraphicsView.drawBackground(self, painter, rect)
+        result = QtWidgets.QGraphicsView.drawBackground(self, painter, rect)
         
         # Stop here if view has no background
         if not self.background_image:
@@ -1522,7 +1522,7 @@ class GraphicViewWidget(QtGui.QGraphicsView):
         '''Default method override to draw origin axis in edit mode
         '''
         # Run default method
-        result =  QtGui.QGraphicsView.drawForeground(self, painter, rect)
+        result =  QtWidgets.QGraphicsView.drawForeground(self, painter, rect)
           
         # Paint axis in edit mode
         if __EDIT_MODE__.get():
@@ -1553,13 +1553,13 @@ class GraphicViewWidget(QtGui.QGraphicsView):
             painter.drawLine(y_line)
     
     
-class DefaultPolygon(QtGui.QGraphicsObject):
+class DefaultPolygon(QtWidgets.QGraphicsObject):
     '''Default polygon class, with move and hover support
     '''
     __DEFAULT_COLOR__ = QtGui.QColor(0,0,0,255)
     
     def __init__(self, parent=None):
-        QtGui.QGraphicsObject.__init__(self, parent=parent)
+        QtWidgets.QGraphicsObject.__init__(self, parent=parent)
         
         if parent:
             self.setParent(parent)
@@ -1574,14 +1574,14 @@ class DefaultPolygon(QtGui.QGraphicsObject):
     def hoverEnterEvent(self, event=None):
         '''Lightens background color on mose over
         '''
-        QtGui.QGraphicsObject.hoverEnterEvent(self, event)
+        QtWidgets.QGraphicsObject.hoverEnterEvent(self, event)
         self._hovered = True
         self.update()
     
     def hoverLeaveEvent(self, event=None):
         '''Resets mouse over background color
         '''
-        QtGui.QGraphicsObject.hoverLeaveEvent(self, event)
+        QtWidgets.QGraphicsObject.hoverLeaveEvent(self, event)
         self._hovered = False
         self.update()
     
@@ -1603,7 +1603,7 @@ class DefaultPolygon(QtGui.QGraphicsObject):
                 self.scene().update()
         
         # Run default action
-        return QtGui.QGraphicsObject.itemChange(self, change, value)
+        return QtWidgets.QGraphicsObject.itemChange(self, change, value)
     
     def get_color(self):
         '''Get polygon color
@@ -1781,7 +1781,7 @@ class PointHandle(DefaultPolygon):
 class Polygon(DefaultPolygon):
     '''
     Picker controls visual graphic object
-    (inherits from QtGui.QGraphicsObject rather than QtGui.QGraphicsItem for signal support)
+    (inherits from QtWidgets.QGraphicsObject rather than QtWidgets.QGraphicsItem for signal support)
     '''
     __DEFAULT_COLOR__ = QtGui.QColor(200,200,200,180)
     __DEFAULT_SELECT_COLOR__ = QtGui.QColor(0,30,0,180)
@@ -1902,13 +1902,13 @@ class Polygon(DefaultPolygon):
         Polygon.__DEFAULT_COLOR__ = color 
         
 
-class PointHandleIndex(QtGui.QGraphicsSimpleTextItem):
+class PointHandleIndex(QtWidgets.QGraphicsSimpleTextItem):
     '''Point handle index text element
     '''
     __DEFAULT_COLOR__ = QtGui.QColor(130,50,50,255)
     
     def __init__(self, parent=None, scene=None, index=0):
-        QtGui.QGraphicsSimpleTextItem.__init__(self, parent, scene)
+        QtWidgets.QGraphicsSimpleTextItem.__init__(self, parent, scene)
         
         # Init defaults
         self.set_size()
@@ -1940,16 +1940,16 @@ class PointHandleIndex(QtGui.QGraphicsSimpleTextItem):
     def setText(self, text):
         '''Override default setText method to force unicode on int index input
         '''
-        return QtGui.QGraphicsSimpleTextItem.setText(self, unicode(text))
+        return QtWidgets.QGraphicsSimpleTextItem.setText(self, unicode(text))
         
         
-class GraphicText(QtGui.QGraphicsSimpleTextItem):
+class GraphicText(QtWidgets.QGraphicsSimpleTextItem):
     '''Picker item text element
     '''
     __DEFAULT_COLOR__ = QtGui.QColor(30,30,30,255)
     
     def __init__(self, parent=None, scene=None):
-        QtGui.QGraphicsSimpleTextItem.__init__(self, parent, scene)
+        QtWidgets.QGraphicsSimpleTextItem.__init__(self, parent, scene)
         
         # Counter view scale
         self.scale_transform = QtGui.QTransform().scale(1, -1)
@@ -2253,60 +2253,60 @@ class PickerItem(DefaultPolygon):
         '''Context menu (right click) in edition mode
         '''
         # Init context menu
-        menu = QtGui.QMenu(self.parent())
+        menu = QtWidgets.QMenu(self.parent())
         
         # Build edit context menu
-        options_action = QtGui.QAction("Options", None)
+        options_action = QtWidgets.QAction("Options", None)
         options_action.triggered.connect(self.edit_options)
         menu.addAction(options_action)
         
-        handles_action = QtGui.QAction("Toggle handles", None)
+        handles_action = QtWidgets.QAction("Toggle handles", None)
         handles_action.triggered.connect(self.toggle_edit_status)
         menu.addAction(handles_action)
         
         menu.addSeparator()
         
         # Shape options menu
-        shape_menu = QtGui.QMenu(menu)
+        shape_menu = QtWidgets.QMenu(menu)
         shape_menu.setTitle('Shape')
         
-        move_action = QtGui.QAction("Move to center", None)
+        move_action = QtWidgets.QAction("Move to center", None)
         move_action.triggered.connect(self.move_to_center)
         shape_menu.addAction(move_action)
         
-        shp_mirror_action = QtGui.QAction("Mirror shape", None)
+        shp_mirror_action = QtWidgets.QAction("Mirror shape", None)
         shp_mirror_action.triggered.connect(self.mirror_shape)
         shape_menu.addAction(shp_mirror_action)
         
-        color_mirror_action = QtGui.QAction("Mirror color", None)
+        color_mirror_action = QtWidgets.QAction("Mirror color", None)
         color_mirror_action.triggered.connect(self.mirror_color)
         shape_menu.addAction(color_mirror_action)
         
         menu.addMenu(shape_menu)
         
-        move_back_action = QtGui.QAction("Move to back", None)
+        move_back_action = QtWidgets.QAction("Move to back", None)
         move_back_action.triggered.connect(self.move_to_back)
         menu.addAction(move_back_action)
         
-        move_front_action = QtGui.QAction("Move to front", None)
+        move_front_action = QtWidgets.QAction("Move to front", None)
         move_front_action.triggered.connect(self.move_to_front)
         menu.addAction(move_front_action)
         
         menu.addSeparator()
         
         # Copy handling
-        copy_action = QtGui.QAction("Copy", None)
+        copy_action = QtWidgets.QAction("Copy", None)
         copy_action.triggered.connect(self.copy_event)
         menu.addAction(copy_action)
         
-        paste_action = QtGui.QAction("Paste", None)
+        paste_action = QtWidgets.QAction("Paste", None)
         if DataCopyDialog.__DATA__:
             paste_action.triggered.connect(self.past_event)
         else:
             paste_action.setEnabled(False)
         menu.addAction(paste_action)
         
-        paste_options_action = QtGui.QAction("Paste Options", None)
+        paste_options_action = QtWidgets.QAction("Paste Options", None)
         if DataCopyDialog.__DATA__:
             paste_options_action.triggered.connect(self.past_option_event)
         else:
@@ -2316,32 +2316,32 @@ class PickerItem(DefaultPolygon):
         menu.addSeparator()
         
         # Duplicate options
-        duplicate_action = QtGui.QAction("Duplicate", None)
+        duplicate_action = QtWidgets.QAction("Duplicate", None)
         duplicate_action.triggered.connect(self.duplicate)
         menu.addAction(duplicate_action)
         
-        mirror_dup_action = QtGui.QAction("Duplicate/mirror", None)
+        mirror_dup_action = QtWidgets.QAction("Duplicate/mirror", None)
         mirror_dup_action.triggered.connect(self.duplicate_and_mirror)
         menu.addAction(mirror_dup_action)
         
         menu.addSeparator()
         
         # Delete
-        remove_action = QtGui.QAction("Remove", None)
+        remove_action = QtWidgets.QAction("Remove", None)
         remove_action.triggered.connect(self.remove)
         menu.addAction(remove_action)
         
         menu.addSeparator()
         
         # Control association
-        ctrls_menu = QtGui.QMenu(menu)
+        ctrls_menu = QtWidgets.QMenu(menu)
         ctrls_menu.setTitle('Ctrls Association')
         
-        select_action = QtGui.QAction("Select", None)
+        select_action = QtWidgets.QAction("Select", None)
         select_action.triggered.connect(self.select_associated_controls)
         ctrls_menu.addAction(select_action)
         
-        replace_action = QtGui.QAction("Replace with selection", None)
+        replace_action = QtWidgets.QAction("Replace with selection", None)
         replace_action.triggered.connect(self.replace_controls_selection)
         ctrls_menu.addAction(replace_action)
         
@@ -2358,10 +2358,10 @@ class PickerItem(DefaultPolygon):
         '''Context menu (right click) out of edition mode (animation)
         '''
         # Init context menu
-        menu = QtGui.QMenu(self.parent())
+        menu = QtWidgets.QMenu(self.parent())
             
 #        # Add reset action
-#        reset_action = QtGui.QAction("Reset", None)
+#        reset_action = QtWidgets.QAction("Reset", None)
 #        reset_action.triggered.connect(self.active_control.reset_to_bind_pose)
 #        menu.addAction(reset_action)
                         
@@ -2415,7 +2415,7 @@ class PickerItem(DefaultPolygon):
         
         # Build menu
         for i in range(len(custom_data)):
-            actions.append(QtGui.QAction(custom_data[i][0], None))
+            actions.append(QtWidgets.QAction(custom_data[i][0], None))
             actions[i].triggered.connect(wrapper(custom_data[i][1]))
         
         return actions
@@ -2498,7 +2498,7 @@ class PickerItem(DefaultPolygon):
         scene = self.scene()
         
         # Move to temp scene
-        tmp_scene = QtGui.QGraphicsScene()
+        tmp_scene = QtWidgets.QGraphicsScene()
         tmp_scene.addItem(self)
         
         # Add to current scene (will be put on top)
@@ -2691,7 +2691,7 @@ class PickerItem(DefaultPolygon):
         
         # Print warning
         if node_missing:
-            QtGui.QMessageBox.warning(self.parent(),
+            QtWidgets.QMessageBox.warning(self.parent(),
                                       "Warning",
                                       "Some target controls do not exist")
         
@@ -2839,7 +2839,7 @@ class PickerItem(DefaultPolygon):
         return data
         
 
-class HandlesPositionWindow(QtGui.QMainWindow):
+class HandlesPositionWindow(QtWidgets.QMainWindow):
     '''Whild window to edit picker item handles local positions
     '''
     __OBJ_NAME__ = 'picker_item_handles_window'
@@ -2851,7 +2851,7 @@ class HandlesPositionWindow(QtGui.QMainWindow):
     def __init__(self,
                  parent=None,
                  picker_item=None):
-        QtGui.QMainWindow.__init__(self, parent=None)
+        QtWidgets.QMainWindow.__init__(self, parent=None)
         
         self.picker_item = picker_item
         
@@ -2867,13 +2867,13 @@ class HandlesPositionWindow(QtGui.QMainWindow):
         self.resize(self.__DEFAULT_WIDTH__, self.__DEFAULT_HEIGHT__)
         
         # Set size policies
-#        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+#        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
 #        sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
 #        self.setSizePolicy(sizePolicy)
         
         # Create main widget
-        self.main_widget = QtGui.QWidget(self)
-        self.main_layout = QtGui.QVBoxLayout(self.main_widget)
+        self.main_widget = QtWidgets.QWidget(self)
+        self.main_layout = QtWidgets.QVBoxLayout(self.main_widget)
         
         self.setCentralWidget(self.main_widget)
         
@@ -2885,7 +2885,7 @@ class HandlesPositionWindow(QtGui.QMainWindow):
         self.populate_table()
         
     def add_position_table(self):
-        self.table = QtGui.QTableWidget(self)
+        self.table = QtWidgets.QTableWidget(self)
         
         self.table.setColumnCount(2)
         self.table.setHorizontalHeaderLabels(['X', 'Y'])
@@ -2938,16 +2938,16 @@ class HandlesPositionWindow(QtGui.QMainWindow):
     
     def closeEvent(self, *args, **kwargs):
         self.display_handles_index(status=False)
-        return QtGui.QMainWindow.closeEvent(self, *args, **kwargs)
+        return QtWidgets.QMainWindow.closeEvent(self, *args, **kwargs)
             
     def show(self, *args, **kwargs):
         '''Override default show function to display related picker handles index
         '''
         self.display_handles_index(status=True)
-        return QtGui.QMainWindow.show(self, *args, **kwargs)
+        return QtWidgets.QMainWindow.show(self, *args, **kwargs)
                 
     
-class ItemOptionsWindow(QtGui.QMainWindow):
+class ItemOptionsWindow(QtWidgets.QMainWindow):
     '''Child window to edit shape options
     '''
     __OBJ_NAME__ = 'ctrl_picker_edit_window'
@@ -2956,7 +2956,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
     #-----------------------------------------------------------------------------------------------
     #    constructor
     def __init__(self, parent=None, picker_item=None):
-        QtGui.QMainWindow.__init__(self, parent=parent)
+        QtWidgets.QMainWindow.__init__(self, parent=parent)
         self.picker_item = picker_item
         
         # Define size
@@ -2979,21 +2979,21 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         self.resize(self.default_width, self.default_height)
         
         # Set size policies
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
         self.setSizePolicy(sizePolicy)
         
         # Create main widget
-        self.main_widget = QtGui.QWidget(self)
-        self.main_layout = QtGui.QHBoxLayout(self.main_widget)
+        self.main_widget = QtWidgets.QWidget(self)
+        self.main_layout = QtWidgets.QHBoxLayout(self.main_widget)
         
-        self.left_layout = QtGui.QVBoxLayout()
+        self.left_layout = QtWidgets.QVBoxLayout()
         self.main_layout.addLayout(self.left_layout)
         
-        self.right_layout = QtGui.QHBoxLayout()
+        self.right_layout = QtWidgets.QHBoxLayout()
         self.main_layout.addLayout(self.right_layout)
         
-        self.control_layout = QtGui.QVBoxLayout()
+        self.control_layout = QtWidgets.QVBoxLayout()
         self.control_layout.setContentsMargins(0,0,0,0)
         self.right_layout.addLayout(self.control_layout)
         
@@ -3029,7 +3029,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
                 self.handles_window.close()
             except:pass 
 
-        QtGui.QMainWindow.closeEvent(self, *args, **kwargs)
+        QtWidgets.QMainWindow.closeEvent(self, *args, **kwargs)
         
     def _update_shape_infos(self):
         self.event_disabled = True
@@ -3073,11 +3073,11 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add vertex count option
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Main Properties')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Add edit check box
         self.handles_cb = CallbackCheckBoxWidget(callback=self.handles_cb_event)
@@ -3086,9 +3086,9 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         layout.addWidget(self.handles_cb)
         
         # Add point count spin box
-        spin_layout = QtGui.QHBoxLayout()
+        spin_layout = QtWidgets.QHBoxLayout()
         
-        spin_label = QtGui.QLabel()
+        spin_label = QtWidgets.QLabel()
         spin_label.setText('Vtx Count')
         spin_layout.addWidget(spin_label)
         
@@ -3111,19 +3111,19 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add position field for precise control positioning
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Position')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Get bary-center
         position = self.picker_item.pos()
         
         # Add X position spin box
-        spin_layout = QtGui.QHBoxLayout()
+        spin_layout = QtWidgets.QHBoxLayout()
         
-        spin_label = QtGui.QLabel()
+        spin_label = QtWidgets.QLabel()
         spin_label.setText('X')
         spin_layout.addWidget(spin_label)
         
@@ -3135,9 +3135,9 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         layout.addLayout(spin_layout)
         
         # Add Y position spin box
-        spin_layout = QtGui.QHBoxLayout()
+        spin_layout = QtWidgets.QHBoxLayout()
         
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText('Y')
         spin_layout.addWidget(label)
         
@@ -3167,11 +3167,11 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add color edition field for polygon 
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Color options')
         
         # Add layout
-        layout = QtGui.QHBoxLayout(group_box)
+        layout = QtWidgets.QHBoxLayout(group_box)
         
         # Add color button
         self.color_button = CallbackButton(callback=self.change_color_event)
@@ -3181,7 +3181,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         # Add alpha spin box
         layout.addStretch()
         
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText('Alpha')
         layout.addWidget(label)
         
@@ -3197,20 +3197,20 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add text option fields 
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Text options')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Add Caption text field
         self.text_field = CallbackLineEdit(self.set_text_event)
         layout.addWidget(self.text_field)
         
         # Add size factor spin box
-        spin_layout = QtGui.QHBoxLayout()
+        spin_layout = QtWidgets.QHBoxLayout()
         
-        spin_label = QtGui.QLabel()
+        spin_label = QtWidgets.QLabel()
         spin_label.setText('Size factor')
         spin_layout.addWidget(spin_label)
         
@@ -3221,7 +3221,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         layout.addLayout(spin_layout)
         
         # Add color layout
-        color_layout = QtGui.QHBoxLayout(group_box)
+        color_layout = QtWidgets.QHBoxLayout(group_box)
         
         # Add color button
         self.text_color_button = CallbackButton(callback=self.change_text_color_event)
@@ -3231,7 +3231,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         # Add alpha spin box
         color_layout.addStretch()
         
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText('Alpha')
         color_layout.addWidget(label)
         
@@ -3250,33 +3250,33 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add scale group box options
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Scale')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Add edit check box
-        self.worldspace_box = QtGui.QCheckBox()
+        self.worldspace_box = QtWidgets.QCheckBox()
         self.worldspace_box.setText('World space')
         
         layout.addWidget(self.worldspace_box)
         
         # Add alpha spin box
-        spin_layout = QtGui.QHBoxLayout()
+        spin_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(spin_layout)
         
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText('Factor')
         spin_layout.addWidget(label)
         
-        self.scale_sb = QtGui.QDoubleSpinBox()
+        self.scale_sb = QtWidgets.QDoubleSpinBox()
         self.scale_sb.setValue(1.1)
         self.scale_sb.setSingleStep(0.05)
         spin_layout.addWidget(self.scale_sb)
         
         # Add scale buttons
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(btn_layout)
         
         btn = CallbackButton(callback=self.scale_event, x=True)
@@ -3298,11 +3298,11 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add custom action mode field group box
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Action Mode')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Add default select mode radio button
         default_rad = CallbackRadioButtonWidget('default',
@@ -3332,11 +3332,11 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add target control association group box
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Control Association')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Init list object
         self.control_list = CallbackListWidget(callback=self.edit_ctrl_name_event)
@@ -3344,7 +3344,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         layout.addWidget(self.control_list)
         
         # Add buttons
-        btn_layout1 = QtGui.QHBoxLayout()
+        btn_layout1 = QtWidgets.QHBoxLayout()
         layout.addLayout(btn_layout1)
         
         btn = CallbackButton(callback=self.add_selected_controls_event)
@@ -3370,11 +3370,11 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         '''Add custom menu management groupe box
         '''
         # Create group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Custom Menus')
         
         # Add layout
-        layout = QtGui.QVBoxLayout(group_box)
+        layout = QtWidgets.QVBoxLayout(group_box)
         
         # Init list object
         self.menus_list = CallbackListWidget(callback=self.edit_menu_event)
@@ -3382,7 +3382,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
         layout.addWidget(self.menus_list)
         
         # Add buttons
-        btn_layout1 = QtGui.QHBoxLayout()
+        btn_layout1 = QtWidgets.QHBoxLayout()
         layout.addLayout(btn_layout1)
         
         btn = CallbackButton(callback=self.new_menu_event)
@@ -3601,10 +3601,10 @@ class ItemOptionsWindow(QtGui.QMainWindow):
             return
         
         # Open input window
-        name, ok = QtGui.QInputDialog.getText(self,
+        name, ok = QtWidgets.QInputDialog.getText(self,
                                               unicode("Ctrl name"),
                                               unicode('New name'),
-                                              mode=QtGui.QLineEdit.Normal,
+                                              mode=QtWidgets.QLineEdit.Normal,
                                               text=unicode(item.text()))
         if not (ok and name):
             return
@@ -3665,7 +3665,7 @@ class ItemOptionsWindow(QtGui.QMainWindow):
     def _add_menu_item(self, text=None):
         '''Add a menu item to menu list widget
         '''
-        item = QtGui.QListWidgetItem()
+        item = QtWidgets.QListWidgetItem()
         item.index = self.menus_list.count()
         if text:
             item.setText(text)
@@ -3758,9 +3758,9 @@ class SaveOverlayWidget(OverlayWidget):
         OverlayWidget.setup(self)
         
         # Add options group box
-        group_box = QtGui.QGroupBox()
+        group_box = QtWidgets.QGroupBox()
         group_box.setTitle('Save options')
-        self.option_layout = QtGui.QVBoxLayout(group_box)
+        self.option_layout = QtWidgets.QVBoxLayout(group_box)
         self.layout.addWidget(group_box)
         
         # Add options
@@ -3771,7 +3771,7 @@ class SaveOverlayWidget(OverlayWidget):
         self.add_confirmation_buttons()
         
         # Add vertical spacer
-        spacer = QtGui.QSpacerItem(0, 0, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        spacer = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.layout.addItem(spacer)
         
         self.data_node = None
@@ -3779,7 +3779,7 @@ class SaveOverlayWidget(OverlayWidget):
     def add_node_save_options(self):
         '''Save data to node option
         '''
-        self.node_option_cb = QtGui.QCheckBox()
+        self.node_option_cb = QtWidgets.QCheckBox()
         self.node_option_cb.setText('Save data to node')
         
         self.option_layout.addWidget(self.node_option_cb)
@@ -3787,14 +3787,14 @@ class SaveOverlayWidget(OverlayWidget):
     def add_file_save_options(self):
         '''Add save to file options
         '''
-        self.file_option_cb = QtGui.QCheckBox()
+        self.file_option_cb = QtWidgets.QCheckBox()
         self.file_option_cb.setText('Save data to file')
         
         self.option_layout.addWidget(self.file_option_cb)
         
-        file_layout = QtGui.QHBoxLayout()
+        file_layout = QtWidgets.QHBoxLayout()
         
-        self.file_path_le = QtGui.QLineEdit()
+        self.file_path_le = QtWidgets.QLineEdit()
         file_layout.addWidget(self.file_path_le)
         
         file_btn = CallbackButton(callback=self.select_file_event)
@@ -3806,9 +3806,9 @@ class SaveOverlayWidget(OverlayWidget):
     def add_confirmation_buttons(self):
         '''Add save confirmation buttons to overlay
         '''
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
 
-        spacer = QtGui.QSpacerItem(0,0, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacer = QtWidgets.QSpacerItem(0,0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         btn_layout.addItem(spacer)
         
         close_btn = CallbackButton(callback=self.cancel_event)
@@ -3819,7 +3819,7 @@ class SaveOverlayWidget(OverlayWidget):
         save_btn.setText('Save')
         btn_layout.addWidget(save_btn)
         
-        spacer = QtGui.QSpacerItem(0,0, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacer = QtWidgets.QSpacerItem(0,0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         btn_layout.addItem(spacer)
         
         self.layout.addLayout(btn_layout)
@@ -3855,7 +3855,7 @@ class SaveOverlayWidget(OverlayWidget):
     def select_file_dialog(self):
         '''Get file dialog window starting in default folder
         '''
-        file_path = QtGui.QFileDialog.getSaveFileName(self,
+        file_path = QtWidgets.QFileDialog.getSaveFileName(self,
                                                       'Choose file',
                                                       get_module_path(),
                                                       'Picker Datas (*.pkr)')
@@ -3909,14 +3909,14 @@ class AboutOverlayWidget(OverlayWidget):
         OverlayWidget.setup(self)
 
         # Add label
-        label = QtGui.QLabel()
+        label = QtWidgets.QLabel()
         label.setText(self.get_text())
         self.layout.addWidget(label)
         
         # Add Close button
-        btn_layout = QtGui.QHBoxLayout()
+        btn_layout = QtWidgets.QHBoxLayout()
 
-        spacer = QtGui.QSpacerItem(0,0, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacer = QtWidgets.QSpacerItem(0,0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         btn_layout.addItem(spacer)
         
         close_btn = CallbackButton(callback=self.hide)
@@ -3924,13 +3924,13 @@ class AboutOverlayWidget(OverlayWidget):
         close_btn.setToolTip('Hide about informations')
         btn_layout.addWidget(close_btn)
         
-        spacer = QtGui.QSpacerItem(0,0, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacer = QtWidgets.QSpacerItem(0,0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         btn_layout.addItem(spacer)
         
         self.layout.addLayout(btn_layout)
         
         # Add vertical spacer
-        spacer = QtGui.QSpacerItem(0, 0, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        spacer = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.layout.addItem(spacer)
         
     def get_text(self):
@@ -3948,15 +3948,17 @@ class AboutOverlayWidget(OverlayWidget):
         return text
     
             
-class MainDockWindow(QtGui.QDockWidget):
+class MainDockWindow(QtWidgets.QDockWidget):
     __OBJ_NAME__ = 'ctrl_picker_window'
     __TITLE__ = 'Anim Picker'
     
     def __init__(self,
                  parent=qt_handlers.get_maya_window(),
                  edit=False ):
+        self.ready = False
+
         '''init pyqt4 GUI'''
-        QtGui.QDockWidget.__init__(self, parent)
+        QtWidgets.QDockWidget.__init__(self, parent)
         
         self.parent =   parent
                 
@@ -3984,7 +3986,7 @@ class MainDockWindow(QtGui.QDockWidget):
         self.resize(self.default_width, self.default_height)
         
         self.setAllowedAreas(QtCore.Qt.LeftDockWidgetArea|QtCore.Qt.RightDockWidgetArea)
-        self.setFeatures(QtGui.QDockWidget.DockWidgetFloatable|QtGui.QDockWidget.DockWidgetMovable|QtGui.QDockWidget.DockWidgetClosable)
+        self.setFeatures(QtWidgets.QDockWidget.DockWidgetFloatable|QtWidgets.QDockWidget.DockWidgetMovable|QtWidgets.QDockWidget.DockWidgetClosable)
         
         # Add to maya window for proper behavior
         maya_window = qt_handlers.get_maya_window()
@@ -3992,8 +3994,8 @@ class MainDockWindow(QtGui.QDockWidget):
         self.setFloating(True)
         
         # Add main widget and vertical layout
-        self.main_widget = QtGui.QWidget(self)
-        self.main_vertical_layout = QtGui.QVBoxLayout(self.main_widget)
+        self.main_widget = QtWidgets.QWidget(self)
+        self.main_vertical_layout = QtWidgets.QVBoxLayout(self.main_widget)
         
         # Add window fields
         self.add_character_selector()
@@ -4003,6 +4005,9 @@ class MainDockWindow(QtGui.QDockWidget):
         # Add main widget to window
         self.setWidget(self.main_widget)
         
+        # Creating is done (workaround for signals being fired off before everything is created)
+        self.ready = True
+
 #        # Add docking event signal
 #        self.connect(self,
 #                     QtCore.SIGNAL('topLevelChanged(bool)'),
@@ -4017,18 +4022,18 @@ class MainDockWindow(QtGui.QDockWidget):
         '''Add Character comboBox selector
         '''
         # Create layout
-        layout = QtGui.QHBoxLayout()
+        layout = QtWidgets.QHBoxLayout()
         self.main_vertical_layout.addLayout(layout)
         
         # Create group box
-        box = QtGui.QGroupBox()
+        box = QtWidgets.QGroupBox()
         box.setTitle('Character Selector')
         box.setFixedHeight(80)
         
         layout.addWidget(box)
         
         # Add layout
-        box_layout = QtGui.QVBoxLayout(box)
+        box_layout = QtWidgets.QVBoxLayout(box)
         
         # Add combo box
         self.char_selector_cb = CallbackComboBox(callback=self.selector_change_event)
@@ -4038,11 +4043,11 @@ class MainDockWindow(QtGui.QDockWidget):
         self.char_selector_cb.nodes = list()
         
         # Add option buttons
-        btns_layout = QtGui.QHBoxLayout()
+        btns_layout = QtWidgets.QHBoxLayout()
         box_layout.addLayout(btns_layout)
         
         # Add horizont spacer
-        spacer = QtGui.QSpacerItem(10,0, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacer = QtWidgets.QSpacerItem(10,0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         btns_layout.addItem(spacer)
         
         # About btn
@@ -4132,13 +4137,17 @@ class MainDockWindow(QtGui.QDockWidget):
             except:pass
         
         # Default close    
-        QtGui.QDockWidget.closeEvent(self, *args, **kwargs)
+        QtWidgets.QDockWidget.closeEvent(self, *args, **kwargs)
     
     def showEvent(self,  *args, **kwargs):
         '''Default showEvent overload
         '''
+        # Prevent firing this event before the window is set up
+        if not self.ready: 
+            return
+
         # Default close    
-        QtGui.QDockWidget.showEvent(self, *args, **kwargs)
+        QtWidgets.QDockWidget.showEvent(self, *args, **kwargs)
         
         # Force char load
         self.refresh()
@@ -4149,6 +4158,10 @@ class MainDockWindow(QtGui.QDockWidget):
     def resizeEvent(self, event):
         '''Resize about overlay on resize event
         '''
+        # Prevent firing this event before the window is set up
+        if not self.ready: 
+            return
+
         size = self.main_widget.size()
         pos = self.main_widget.pos()
         
@@ -4158,7 +4171,7 @@ class MainDockWindow(QtGui.QDockWidget):
         self.save_widget.resize(size)
         self.save_widget.move(pos)
         
-        return QtGui.QDockWidget.resizeEvent(self, event)
+        return QtWidgets.QDockWidget.resizeEvent(self, event)
     
     def show_about_infos(self):
         '''Open animation picker about and help infos
@@ -4271,10 +4284,10 @@ class MainDockWindow(QtGui.QDockWidget):
         (edit mode only)
         '''
         # Open input window
-        name, ok = QtGui.QInputDialog.getText(self,
+        name, ok = QtWidgets.QInputDialog.getText(self,
                                               self.tr("New character"),
                                               self.tr('Node name'),
-                                              QtGui.QLineEdit.Normal,
+                                              QtWidgets.QLineEdit.Normal,
                                               self.tr('PICKER_DATA') )
         if not (ok and name):
             return
@@ -4307,11 +4320,11 @@ class MainDockWindow(QtGui.QDockWidget):
             return True
         
         # Open question window
-        answer = QtGui.QMessageBox.question(self,
+        answer = QtWidgets.QMessageBox.question(self,
                                             'Changes detected',
                                             'Any changes will be lost, proceed any way ?',
-                                     buttons = QtGui.QMessageBox.No | QtGui.QMessageBox.Yes)
-        return answer == QtGui.QMessageBox.Yes
+                                     buttons = QtWidgets.QMessageBox.No | QtWidgets.QMessageBox.Yes)
+        return answer == QtWidgets.QMessageBox.Yes
     
     def get_current_namespace(self):
         return self.get_current_data_node().get_namespace()
@@ -4366,14 +4379,14 @@ class MainDockWindow(QtGui.QDockWidget):
         
         # Block save in anim mode
         if not __EDIT_MODE__.get():
-            QtGui.QMessageBox.warning(self,
+            QtWidgets.QMessageBox.warning(self,
                                       "Warning",
                                       "Save is not permited in anim mode")
             return
         
         # Block save on referenced nodes
         if data_node.is_referenced():
-            QtGui.QMessageBox.warning(self,
+            QtWidgets.QMessageBox.warning(self,
                                       "Warning",
                                       "Save is not permited on referenced nodes")
             return
@@ -4451,15 +4464,17 @@ def load(edit=False, multi=False):
     '''
     # Return existing window if not multi option
     # Force multi in edit mode to prevent locked window issues
+    """
     if not (edit or multi):
         dock_pt = OpenMayaUI.MQtUtil.findControl(MainDockWindow.__OBJ_NAME__)
         if dock_pt:
             # Get dock qt instance
             dock_widget = qt_handlers.wrap_instance(long(dock_pt), QtCore.QObject)
             dock_widget.show()
-            dock_widget.raise_()
+            #dock_widget.raise_()
     
             return dock_widget
+    """
     
     # Init UI
     dock_widget = MainDockWindow(parent=qt_handlers.get_maya_window(),

--- a/anim_picker/gui.py
+++ b/anim_picker/gui.py
@@ -3456,7 +3456,7 @@ class ItemOptionsWindow(QtWidgets.QMainWindow):
             return
         
         # Open color picker dialog
-        color = QtGui.QColorDialog.getColor(initial=self.picker_item.get_color(),
+        color = QtWidgets.QColorDialog.getColor(initial=self.picker_item.get_color(),
                                             parent=self)
         
         # Abort on invalid color (cancel button)
@@ -3532,7 +3532,7 @@ class ItemOptionsWindow(QtWidgets.QMainWindow):
             return
         
         # Open color picker dialog
-        color = QtGui.QColorDialog.getColor(initial=self.picker_item.get_text_color(),
+        color = QtWidgets.QColorDialog.getColor(initial=self.picker_item.get_text_color(),
                                             parent=self)
         
         # Abort on invalid color (cancel button)

--- a/anim_picker/handlers/qt_handlers.py
+++ b/anim_picker/handlers/qt_handlers.py
@@ -6,13 +6,10 @@ from maya import OpenMayaUI
 
 # Main Qt support
 try:
-    from PyQt4 import QtCore, QtGui, QtOpenGL
+    from anim_picker.Qt import QtCore, QtGui, QtOpenGL, QtWidgets
 except:
-    try:
-        from PySide import QtCore, QtGui, QtOpenGL
-    except:
-        raise Exception, 'Failed to import PyQt4 or Pyside'
-    
+    raise Exception, 'Failed to import Qt.py'
+
 try:
     import sip
 except:
@@ -22,7 +19,10 @@ except:
         try:
             from PySide import shiboken
         except:
-            raise Exception, 'Failed to import sip or shiboken'
+            try:
+                import shiboken2 as shiboken
+            except:
+                raise Exception, 'Failed to import sip or shiboken'
         
     
 # Instance handling
@@ -48,7 +48,7 @@ def get_maya_window():
     '''
     try:
         ptr = OpenMayaUI.MQtUtil.mainWindow()
-        return wrap_instance(long(ptr), QtGui.QMainWindow)
+        return wrap_instance(long(ptr), QtWidgets.QMainWindow)
     except:
         #    fails at import on maya launch since ui isn't up yet
         return None


### PR DESCRIPTION
* Added support for Maya 2017 which uses Qt5 and Pyside2

* To preserve backwards compatibility, the Qt.py wrapper
was added. Qt.py uses strict Qt5, even when run on Qt4,
so the following changes were made to  gui.py:

 - QtQui -> QtWidgets where needed
 - New signal syntax (old SIGNAL still works on PySide2,
   but not on Qt.py which is stricter)